### PR TITLE
Support earlier versions of .NET.

### DIFF
--- a/getopt.net/GetOpt.cs
+++ b/getopt.net/GetOpt.cs
@@ -92,8 +92,12 @@ namespace getopt.net {
         /// Compiled Regex.
         /// </summary>
         /// <returns>A pre-compiled and optimised regular expression object.</returns>
+#if NET7_0_OR_GREATER
         [GeneratedRegex(@"([\s]|[=])", RegexOptions.IgnoreCase | RegexOptions.Compiled)]
         protected static partial Regex ArgumentSplitter();
+#else
+        protected static Regex ArgumentSplitter() => new(@"([\s]|[=])", RegexOptions.IgnoreCase | RegexOptions.Compiled);
+#endif
 
         /// <summary>
         /// Resets the option position to 1.
@@ -294,7 +298,11 @@ namespace getopt.net {
             }
 
             optName = splitString[0];
+#if NET6_0_OR_GREATER
             argVal = string.Join("", splitString[2..]);
+#else
+            argVal = string.Join("", splitString.Skip(2));
+#endif
             return true;
         }
 

--- a/getopt.net/getopt.net.csproj
+++ b/getopt.net/getopt.net.csproj
@@ -1,8 +1,9 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
-    <ImplicitUsings>enable</ImplicitUsings>
+    <TargetFrameworks>net46;net6.0;net7.0</TargetFrameworks>
+    <ImplicitUsings>disable</ImplicitUsings>
+    <LangVersion>11</LangVersion>
     <Nullable>enable</Nullable>
     <Description>Getopt.net is a cleanroom port of GNU getopt, adapted for common patterns found in .net framework libraries.
 
@@ -31,4 +32,10 @@ GitHub: https://github.com/SimonCahill/getopt.net</Description>
     <WarningLevel>4</WarningLevel>
     <SignAssembly>true</SignAssembly>
   </PropertyGroup>
+
+  <ItemGroup>
+    <Using Include="System" />
+    <Using Include="System.Linq" />
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
I have the misfortune to be working on projects that still use .NET Framework 4.6.2, so I tried to see how far back I could push the version support.

I think .NET 5 worked, but that's out of support, so I removed it again. I wasn't able to get .NET Standard 2.1 to work without removing `<Nullable>enable</Nullable>`, and I didn't want to do that. I didn't try with Framework 4.5 or Core 3.1.