### PR TITLE
Enable double dash stops parsing by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # getop.net changelog
 
+# v0.3.1
+This is a minor release related to #11.
+
+# Changes:
+
+ - DoubleDashStopsParsing is now default true.
+ - Bumped up version to 0.3.1
+
 # v0.3.0
 
  - Added check to determine whether 0x01 must be returned, depending on whether or not `ShortOpts[0] == '-'`.

--- a/getopt.net.sln
+++ b/getopt.net.sln
@@ -7,6 +7,14 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "getopt.net", "getopt.net\ge
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "getopt.net.tests", "getopt.net.tests\getopt.net.tests.csproj", "{61E603C3-E53F-439A-9945-71EB7D13DC64}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{B994D393-9D31-4B65-BCCB-3FF2ACC910C3}"
+	ProjectSection(SolutionItems) = preProject
+		CHANGELOG.md = CHANGELOG.md
+		Doxyfile = Doxyfile
+		LICENSE = LICENSE
+		README.md = README.md
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU

--- a/getopt.net.tests/GetOptTests_RealWorld.cs
+++ b/getopt.net.tests/GetOptTests_RealWorld.cs
@@ -358,99 +358,99 @@ namespace getopt.net.tests {
             Assert.AreEqual("--test", optArg);
 
             optChar = (char)opt.GetNextOpt(out optArg);
-			Assert.AreEqual(GetOpt.NonOptChar, optChar);
-			Assert.IsNotNull(optArg);
-			Assert.AreEqual("-xzf", optArg);
-		}
+            Assert.AreEqual(GetOpt.NonOptChar, optChar);
+            Assert.IsNotNull(optArg);
+            Assert.AreEqual("-xzf", optArg);
+        }
 
-		[TestMethod]
+        [TestMethod]
         [ExpectedException(typeof(ParseException))]
-		public void TestDoubleDashStopsParsing_and_IgnoreInvalidOptions_False() {
-			var opt = new GetOpt {
-				AppArgs = new[] { "-hcv", "--", "--test", "-xzf" },
-				DoubleDashStopsParsing = false, // this is true by default
+        public void TestDoubleDashStopsParsing_and_IgnoreInvalidOptions_False() {
+            var opt = new GetOpt {
+                AppArgs = new[] { "-hcv", "--", "--test", "-xzf" },
+                DoubleDashStopsParsing = false, // this is true by default
                 IgnoreInvalidOptions = false, // this is default true
-				Options = new Option[] {
-					new Option("help", ArgumentType.None, 'h'),
-					new Option("config", ArgumentType.Optional, 'c'),
-					new Option("verbose", ArgumentType.None, 'v'),
-					new Option("test", ArgumentType.None, 't'),
-					new Option("extract", ArgumentType.None, 'x'),
-					new Option("zip", ArgumentType.None, 'z'),
-					new Option("find", ArgumentType.None, 'f')
-				}
-			};
+                Options = new Option[] {
+                    new Option("help", ArgumentType.None, 'h'),
+                    new Option("config", ArgumentType.Optional, 'c'),
+                    new Option("verbose", ArgumentType.None, 'v'),
+                    new Option("test", ArgumentType.None, 't'),
+                    new Option("extract", ArgumentType.None, 'x'),
+                    new Option("zip", ArgumentType.None, 'z'),
+                    new Option("find", ArgumentType.None, 'f')
+                }
+            };
 
-			var optChar = (char)opt.GetNextOpt(out var optArg);
-			Assert.AreEqual('h', optChar);
-			Assert.IsNull(optArg);
+            var optChar = (char)opt.GetNextOpt(out var optArg);
+            Assert.AreEqual('h', optChar);
+            Assert.IsNull(optArg);
 
-			optChar = (char)opt.GetNextOpt(out optArg);
-			Assert.AreEqual('c', optChar);
-			Assert.IsNull(optArg);
+            optChar = (char)opt.GetNextOpt(out optArg);
+            Assert.AreEqual('c', optChar);
+            Assert.IsNull(optArg);
 
-			optChar = (char)opt.GetNextOpt(out optArg);
-			Assert.AreEqual('v', optChar);
-			Assert.IsNull(optArg);
+            optChar = (char)opt.GetNextOpt(out optArg);
+            Assert.AreEqual('v', optChar);
+            Assert.IsNull(optArg);
 
             // At this point, "--" should be encountered.
             // This is will throw an exception if "IgnoreInvalidOptions" is false
             optChar = (char)opt.GetNextOpt(out optArg);
-		}
+        }
 
-		[TestMethod]
-		public void TestDoubleDashStopsParsing_False() {
-			var opt = new GetOpt {
-				AppArgs = new[] { "-hcv", "--", "--test", "-xzf" },
-				DoubleDashStopsParsing = false, // this is true by default
-				Options = new Option[] {
-					new Option("help", ArgumentType.None, 'h'),
-					new Option("config", ArgumentType.Optional, 'c'),
-					new Option("verbose", ArgumentType.None, 'v'),
-					new Option("test", ArgumentType.None, 't'),
-					new Option("extract", ArgumentType.None, 'x'),
-					new Option("zip", ArgumentType.None, 'z'),
-					new Option("find", ArgumentType.None, 'f')
-				}
-			};
+        [TestMethod]
+        public void TestDoubleDashStopsParsing_False() {
+            var opt = new GetOpt {
+                AppArgs = new[] { "-hcv", "--", "--test", "-xzf" },
+                DoubleDashStopsParsing = false, // this is true by default
+                Options = new Option[] {
+                    new Option("help", ArgumentType.None, 'h'),
+                    new Option("config", ArgumentType.Optional, 'c'),
+                    new Option("verbose", ArgumentType.None, 'v'),
+                    new Option("test", ArgumentType.None, 't'),
+                    new Option("extract", ArgumentType.None, 'x'),
+                    new Option("zip", ArgumentType.None, 'z'),
+                    new Option("find", ArgumentType.None, 'f')
+                }
+            };
 
-			var optChar = (char)opt.GetNextOpt(out var optArg);
-			Assert.AreEqual('h', optChar);
-			Assert.IsNull(optArg);
+            var optChar = (char)opt.GetNextOpt(out var optArg);
+            Assert.AreEqual('h', optChar);
+            Assert.IsNull(optArg);
 
-			optChar = (char)opt.GetNextOpt(out optArg);
-			Assert.AreEqual('c', optChar);
-			Assert.IsNull(optArg);
+            optChar = (char)opt.GetNextOpt(out optArg);
+            Assert.AreEqual('c', optChar);
+            Assert.IsNull(optArg);
 
-			optChar = (char)opt.GetNextOpt(out optArg);
-			Assert.AreEqual('v', optChar);
-			Assert.IsNull(optArg);
+            optChar = (char)opt.GetNextOpt(out optArg);
+            Assert.AreEqual('v', optChar);
+            Assert.IsNull(optArg);
 
-			// At this point, "--" should be encountered.
-			// This is an invalid option and GetNextOpt should
+            // At this point, "--" should be encountered.
+            // This is an invalid option and GetNextOpt should
             // return '?'
 
-			optChar = (char)opt.GetNextOpt(out optArg);
-			Assert.AreEqual(GetOpt.InvalidOptChar, optChar);
-			Assert.IsNotNull(optArg);
-			Assert.AreEqual("--", optArg);
+            optChar = (char)opt.GetNextOpt(out optArg);
+            Assert.AreEqual(GetOpt.InvalidOptChar, optChar);
+            Assert.IsNotNull(optArg);
+            Assert.AreEqual("--", optArg);
 
-			optChar = (char)opt.GetNextOpt(out optArg);
-			Assert.AreEqual('t', optChar);
-			Assert.IsNull(optArg);
+            optChar = (char)opt.GetNextOpt(out optArg);
+            Assert.AreEqual('t', optChar);
+            Assert.IsNull(optArg);
 
-			optChar = (char)opt.GetNextOpt(out optArg);
-			Assert.AreEqual('x', optChar);
-			Assert.IsNull(optArg);
+            optChar = (char)opt.GetNextOpt(out optArg);
+            Assert.AreEqual('x', optChar);
+            Assert.IsNull(optArg);
 
-			optChar = (char)opt.GetNextOpt(out optArg);
-			Assert.AreEqual('z', optChar);
-			Assert.IsNull(optArg);
+            optChar = (char)opt.GetNextOpt(out optArg);
+            Assert.AreEqual('z', optChar);
+            Assert.IsNull(optArg);
 
-			optChar = (char)opt.GetNextOpt(out optArg);
-			Assert.AreEqual('f', optChar);
-			Assert.IsNull(optArg);
-		}
+            optChar = (char)opt.GetNextOpt(out optArg);
+            Assert.AreEqual('f', optChar);
+            Assert.IsNull(optArg);
+        }
 
-	}
+    }
 }

--- a/getopt.net.tests/GetOptTests_RealWorld.cs
+++ b/getopt.net.tests/GetOptTests_RealWorld.cs
@@ -320,5 +320,137 @@ namespace getopt.net.tests {
             optChar = (char)opt.GetNextOpt(out optArg);
         }
 
-    }
+        [TestMethod]
+        public void TestDoubleDashStopsParsing_True() {
+            var opt = new GetOpt {
+                AppArgs = new[] { "-hcv", "--", "--test", "-xzf" },
+                DoubleDashStopsParsing = true, // this is true by default
+                Options = new Option[] {
+                    new Option("help", ArgumentType.None, 'h'),
+                    new Option("config", ArgumentType.Optional, 'c'),
+                    new Option("verbose", ArgumentType.None, 'v'),
+                    new Option("test", ArgumentType.None, 't'),
+                    new Option("extract", ArgumentType.None, 'x'),
+                    new Option("zip", ArgumentType.None, 'z'),
+                    new Option("find", ArgumentType.None, 'f')
+                }
+            };
+
+            var optChar = (char)opt.GetNextOpt(out var optArg);
+            Assert.AreEqual('h', optChar);
+            Assert.IsNull(optArg);
+
+            optChar = (char)opt.GetNextOpt(out optArg);
+            Assert.AreEqual('c', optChar);
+            Assert.IsNull(optArg);
+
+            optChar = (char)opt.GetNextOpt(out optArg);
+            Assert.AreEqual('v', optChar);
+            Assert.IsNull(optArg);
+
+            // At this point, "--" should be encountered.
+            // This is ignored and the next option is returned via optArg.
+            // optChar should == 1
+
+            optChar = (char)opt.GetNextOpt(out optArg);
+            Assert.AreEqual(GetOpt.NonOptChar, optChar);
+            Assert.IsNotNull(optArg);
+            Assert.AreEqual("--test", optArg);
+
+            optChar = (char)opt.GetNextOpt(out optArg);
+			Assert.AreEqual(GetOpt.NonOptChar, optChar);
+			Assert.IsNotNull(optArg);
+			Assert.AreEqual("-xzf", optArg);
+		}
+
+		[TestMethod]
+        [ExpectedException(typeof(ParseException))]
+		public void TestDoubleDashStopsParsing_and_IgnoreInvalidOptions_False() {
+			var opt = new GetOpt {
+				AppArgs = new[] { "-hcv", "--", "--test", "-xzf" },
+				DoubleDashStopsParsing = false, // this is true by default
+                IgnoreInvalidOptions = false, // this is default true
+				Options = new Option[] {
+					new Option("help", ArgumentType.None, 'h'),
+					new Option("config", ArgumentType.Optional, 'c'),
+					new Option("verbose", ArgumentType.None, 'v'),
+					new Option("test", ArgumentType.None, 't'),
+					new Option("extract", ArgumentType.None, 'x'),
+					new Option("zip", ArgumentType.None, 'z'),
+					new Option("find", ArgumentType.None, 'f')
+				}
+			};
+
+			var optChar = (char)opt.GetNextOpt(out var optArg);
+			Assert.AreEqual('h', optChar);
+			Assert.IsNull(optArg);
+
+			optChar = (char)opt.GetNextOpt(out optArg);
+			Assert.AreEqual('c', optChar);
+			Assert.IsNull(optArg);
+
+			optChar = (char)opt.GetNextOpt(out optArg);
+			Assert.AreEqual('v', optChar);
+			Assert.IsNull(optArg);
+
+            // At this point, "--" should be encountered.
+            // This is will throw an exception if "IgnoreInvalidOptions" is false
+            optChar = (char)opt.GetNextOpt(out optArg);
+		}
+
+		[TestMethod]
+		public void TestDoubleDashStopsParsing_False() {
+			var opt = new GetOpt {
+				AppArgs = new[] { "-hcv", "--", "--test", "-xzf" },
+				DoubleDashStopsParsing = false, // this is true by default
+				Options = new Option[] {
+					new Option("help", ArgumentType.None, 'h'),
+					new Option("config", ArgumentType.Optional, 'c'),
+					new Option("verbose", ArgumentType.None, 'v'),
+					new Option("test", ArgumentType.None, 't'),
+					new Option("extract", ArgumentType.None, 'x'),
+					new Option("zip", ArgumentType.None, 'z'),
+					new Option("find", ArgumentType.None, 'f')
+				}
+			};
+
+			var optChar = (char)opt.GetNextOpt(out var optArg);
+			Assert.AreEqual('h', optChar);
+			Assert.IsNull(optArg);
+
+			optChar = (char)opt.GetNextOpt(out optArg);
+			Assert.AreEqual('c', optChar);
+			Assert.IsNull(optArg);
+
+			optChar = (char)opt.GetNextOpt(out optArg);
+			Assert.AreEqual('v', optChar);
+			Assert.IsNull(optArg);
+
+			// At this point, "--" should be encountered.
+			// This is an invalid option and GetNextOpt should
+            // return '?'
+
+			optChar = (char)opt.GetNextOpt(out optArg);
+			Assert.AreEqual(GetOpt.InvalidOptChar, optChar);
+			Assert.IsNotNull(optArg);
+			Assert.AreEqual("--", optArg);
+
+			optChar = (char)opt.GetNextOpt(out optArg);
+			Assert.AreEqual('t', optChar);
+			Assert.IsNull(optArg);
+
+			optChar = (char)opt.GetNextOpt(out optArg);
+			Assert.AreEqual('x', optChar);
+			Assert.IsNull(optArg);
+
+			optChar = (char)opt.GetNextOpt(out optArg);
+			Assert.AreEqual('z', optChar);
+			Assert.IsNull(optArg);
+
+			optChar = (char)opt.GetNextOpt(out optArg);
+			Assert.AreEqual('f', optChar);
+			Assert.IsNull(optArg);
+		}
+
+	}
 }

--- a/getopt.net.tests/getopt.net.tests.csproj
+++ b/getopt.net.tests/getopt.net.tests.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="3.0.2" />
     <PackageReference Include="MSTest.TestFramework" Version="3.0.2" />
     <PackageReference Include="coverlet.collector" Version="3.2.0"><IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/getopt.net/GetOpt.cs
+++ b/getopt.net/GetOpt.cs
@@ -27,7 +27,7 @@ namespace getopt.net {
         /// <summary>
         /// Gets or sets a value indicating whether or not "--" stops parsing.
         /// </summary>
-        public bool DoubleDashStopsParsing { get; set; } = false;
+        public bool DoubleDashStopsParsing { get; set; } = true;
 
         /// <summary>
         /// Gets or sets the arguments to parse.

--- a/getopt.net/Option.cs
+++ b/getopt.net/Option.cs
@@ -8,6 +8,38 @@ namespace getopt.net {
 	public struct Option {
 
 		/// <summary>
+		/// Constructs a new, empty instance of this struct.
+		/// </summary>
+		public Option() { }
+
+		/// <summary>
+		/// Constructs a new instance of this struct.
+		/// </summary>
+		/// <param name="name">The name of the argument.</param>
+		/// <param name="argType">The argument type.</param>
+		/// <param name="flag">The flag.</param>
+		/// <param name="value">The value of the option.</param>
+		public Option(string name, ArgumentType argType, IntPtr flag, char value) {
+			Name = name;
+			ArgumentType = argType;
+			Flag = flag;
+			Value = value;
+		}
+
+		/// <summary>
+		/// Constructs a new instance of this struct.
+		/// </summary>
+		/// <param name="name">The name of the argument.</param>
+		/// <param name="argType">The argument type.</param>
+		/// <param name="value">The value of the option.</param>
+		public Option(string name, ArgumentType argType, char value) {
+			Name = name;
+			ArgumentType = argType;
+			Flag = IntPtr.Zero;
+			Value = value;
+		}
+
+		/// <summary>
 		/// The name of the (long) option
 		/// </summary>
 		/// <remarks >

--- a/getopt.net/getopt.net.csproj
+++ b/getopt.net/getopt.net.csproj
@@ -15,12 +15,12 @@ GitHub: https://github.com/SimonCahill/getopt.net</Description>
     <PublisherName>Simon Cahill</PublisherName>
     <SupportUrl>https://docs.simonc.eu/docs/getopt.net</SupportUrl>
     <ReleaseVersion>0.3.1</ReleaseVersion>
-    <Version >0.3.1</Version>
+    <Version>0.3.1</Version>
     <SynchReleaseVersion>true</SynchReleaseVersion>
-    <RepositoryUrl >https://github.com/SimonCahill/getopt.net</RepositoryUrl>
-    <PackageProjectUrl >https://docs.simonc.eu/docs/getopt.net</PackageProjectUrl>
-    <RepositoryType >Git</RepositoryType>
-    <PackageLicenseFile >../LICENSE.md</PackageLicenseFile>
+    <RepositoryUrl>https://github.com/SimonCahill/getopt.net</RepositoryUrl>
+    <PackageProjectUrl>https://docs.simonc.eu/docs/getopt.net</PackageProjectUrl>
+    <RepositoryType>Git</RepositoryType>
+    <PackageLicenseFile>../LICENSE.md</PackageLicenseFile>
 
   </PropertyGroup>
 

--- a/getopt.net/getopt.net.csproj
+++ b/getopt.net/getopt.net.csproj
@@ -14,11 +14,13 @@ GitHub: https://github.com/SimonCahill/getopt.net</Description>
     <PackageId>getopt.net-bsd</PackageId>
     <PublisherName>Simon Cahill</PublisherName>
     <SupportUrl>https://docs.simonc.eu/docs/getopt.net</SupportUrl>
-    <ReleaseVersion>0.3.0</ReleaseVersion>
+    <ReleaseVersion>0.3.1</ReleaseVersion>
+    <Version >0.3.1</Version>
     <SynchReleaseVersion>true</SynchReleaseVersion>
     <RepositoryUrl >https://github.com/SimonCahill/getopt.net</RepositoryUrl>
     <PackageProjectUrl >https://docs.simonc.eu/docs/getopt.net</PackageProjectUrl>
     <RepositoryType >Git</RepositoryType>
+    <PackageLicenseFile >../LICENSE.md</PackageLicenseFile>
 
   </PropertyGroup>
 


### PR DESCRIPTION
This is a minor release related to #11.

Changes:
 - `DoubleDashStopsParsing` is now default `true`.
 - Bumped up version to 0.3.1

# Issues fixed

This PR closes and fixes #11 