### PR TITLE
Removed support for Option.Flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,9 +35,9 @@ getopt.ShortOpts = "abC:dE:f:GhIjkLmnop:q:r:";
 ### Customisation is available with long opts:
 ```csharp
 getopt.Options = new[] {
-    new Option { Name = "help", ArgumentType = ArgumentType.None, Flag = IntPtr.Zero, Value = 'h' },
-    new Option("config", ArgumentType.Required, IntPtr.Zero, 'c'),
-    new Option("version", ArgumentType.Optional, IntPtr.Zero, 'v')
+    new Option { Name = "help", ArgumentType = ArgumentType.None, Flag = Value = 'h' },
+    new Option("config", ArgumentType.Required, 'c'),
+    new Option("version", ArgumentType.Optional, 'v')
 };
 ```
 
@@ -59,11 +59,6 @@ The exceptions *do* contain more info, however.
 At the time of writing this, I have not figured out all the details of using the library!
 Anything written here, until noted otherwise, is **subject to change!**
 
-# Things that __don't__ work
-
-I forgot to implement the whole "provide a flag pointer" functionality.
-I'll do that later; it needs unsafe code anyway, so it'll have to be in its own little method.
-
 ## Basic usage
 
 ```csharp
@@ -74,10 +69,10 @@ static void Main(string[] args) {
 
     var getopt = new Getopt {
         Options = new[] {
-            new Option("help",    ArgumentType.None, IntPtr.Zero, 'h'),
-            new Option("version", ArgumentType.None, IntPtr.Zero, 'v'),
+            new Option("help",    ArgumentType.None, 'h'),
+            new Option("version", ArgumentType.None, 'v'),
             // or, alternatively
-            new Option { Name = "config", ArgumentType.Required, IntPtr.Zero, 'c' }
+            new Option { Name = "config", ArgumentType.Required, 'c' }
         },
         ShortOpts = "hvc:",
         DoubleDashStopsParsing = true, // optional

--- a/README.md
+++ b/README.md
@@ -75,7 +75,6 @@ static void Main(string[] args) {
             new Option { Name = "config", ArgumentType.Required, 'c' }
         },
         ShortOpts = "hvc:",
-        DoubleDashStopsParsing = true, // optional
         AppArgs = args, // REQUIRED
         OnlyShortOpts = false,
         // other options here
@@ -92,7 +91,49 @@ static void Main(string[] args) {
         }
     }
 }
+```
 
+```vbnet
+Imports getopt.net
+
+module Program
+
+    Dim _progOptions() As [Option] = {
+        New [Option]("help", ArgumentType.None, "h"c),
+        New [Option]("version", ArgumentType.None, "v"c),
+        New [Option]("file", ArgumentType.Required, "f"c)
+    }
+
+    Dim _progShortOptions As String = "hvf:"
+
+    sub Main(args as string())
+        Dim getopt = New GetOpt With {
+            .AppArgs = args,
+            .Options = _progOptions,
+            .ShortOpts = _progShortOptions
+        }
+
+        Dim optChar = 0
+        Dim optArg As String = Nothing
+        Dim fileToRead As String = Nothing
+
+        While optChar <> -1
+            optChar = getopt.GetNextOpt(optArg)
+
+            Select Case optChar
+                Case Convert.ToInt32("h"c)
+                    ' do something
+                    Return
+                Case Convert.ToInt32("v"c)
+                    ' do something else
+                    Return
+                Case Convert.ToInt32("f"c)
+                    ' do something with optArg
+            End Select
+        End While
+    end sub
+
+end module
 ```
 
 # Bugs and errors

--- a/README.md
+++ b/README.md
@@ -56,10 +56,9 @@ The exceptions *do* contain more info, however.
 
 # Usage:
 
-At the time of writing this, I have not figured out all the details of using the library!
-Anything written here, until noted otherwise, is **subject to change!**
+For a more detailled description of using getopt.net, please consult the Wiki.
 
-## Basic usage
+## Basic usage in C#
 
 ```csharp
 
@@ -92,6 +91,8 @@ static void Main(string[] args) {
     }
 }
 ```
+
+## Basic usage in VB.Net
 
 ```vbnet
 Imports getopt.net

--- a/getopt.net.tests/GetOptTests_RealWorld.cs
+++ b/getopt.net.tests/GetOptTests_RealWorld.cs
@@ -9,7 +9,7 @@ namespace getopt.net.tests {
         public void TestGetNextOptLong() {
             var opt = new GetOpt();
             opt.AppArgs = new[] { "--help" };
-            opt.Options = new[] { new Option { Name = "help", ArgumentType = ArgumentType.None, Flag = IntPtr.Zero, Value = 'h' } };
+            opt.Options = new[] { new Option { Name = "help", ArgumentType = ArgumentType.None, Value = 'h' } };
 
             string? optArg = "";
             char optChar = (char)opt.GetNextOpt(out optArg);
@@ -21,7 +21,7 @@ namespace getopt.net.tests {
         public void TestGetNextOptLongWithRequiredArg_SeperatedByEquals() {
             var opt = new GetOpt();
             opt.AppArgs = new[] { "--test=test" };
-            opt.Options = new[] { new Option { Name = "test", ArgumentType = ArgumentType.Required, Flag = IntPtr.Zero, Value = 't' } };
+            opt.Options = new[] { new Option { Name = "test", ArgumentType = ArgumentType.Required, Value = 't' } };
 
             string? optArg = "";
             char optChar = (char)opt.GetNextOpt(out optArg);
@@ -33,7 +33,7 @@ namespace getopt.net.tests {
         public void TestGetNextOptLongWithRequiredArgs_SeparatedBySpace() {
             var opt = new GetOpt();
             opt.AppArgs = new[] { "--test test" };
-            opt.Options = new[] { new Option { Name = "test", ArgumentType = ArgumentType.Required, Flag = IntPtr.Zero, Value = 't' } };
+            opt.Options = new[] { new Option { Name = "test", ArgumentType = ArgumentType.Required, Value = 't' } };
 
             string? optArg = "";
             char optChar = (char)opt.GetNextOpt(out optArg);
@@ -45,7 +45,7 @@ namespace getopt.net.tests {
         public void TestGetNextOptLongWithRequiredArgs_SeparatedByArg() {
             var opt = new GetOpt();
             opt.AppArgs = new[] { "--test", "test" };
-            opt.Options = new[] { new Option { Name = "test", ArgumentType = ArgumentType.Required, Flag = IntPtr.Zero, Value = 't' } };
+            opt.Options = new[] { new Option { Name = "test", ArgumentType = ArgumentType.Required, Value = 't' } };
 
             string? optArg = "";
             char optChar = (char)opt.GetNextOpt(out optArg);
@@ -58,10 +58,10 @@ namespace getopt.net.tests {
             var opt = new GetOpt();
             opt.AppArgs = new[] { "--test", "test", "--test2", "--test3=test3", "--test4 test4" };
             opt.Options = new[] {
-                new Option { Name = "test",     ArgumentType = ArgumentType.Required,   Flag = IntPtr.Zero, Value = 't' },
-                new Option { Name = "test2",    ArgumentType = ArgumentType.None,       Flag = IntPtr.Zero, Value = '1' },
-                new Option { Name = "test3",    ArgumentType = ArgumentType.Optional,   Flag = IntPtr.Zero, Value = '2' },
-                new Option { Name = "test4",    ArgumentType = ArgumentType.Required,   Flag = IntPtr.Zero, Value = '3' }
+                new Option { Name = "test",     ArgumentType = ArgumentType.Required,   Value = 't' },
+                new Option { Name = "test2",    ArgumentType = ArgumentType.None,       Value = '1' },
+                new Option { Name = "test3",    ArgumentType = ArgumentType.Optional,   Value = '2' },
+                new Option { Name = "test4",    ArgumentType = ArgumentType.Required,   Value = '3' }
             };
 
             char optChar = (char)opt.GetNextOpt(out string? optArg);
@@ -104,9 +104,9 @@ namespace getopt.net.tests {
         public void TestGetNextOptShort_WithFallbackToLongOpt() {
             var opt = new GetOpt();
             opt.Options = new[] {
-                new Option { Name = "help",     ArgumentType = ArgumentType.None,       Flag = IntPtr.Zero,     Value = 'h' },
-                new Option { Name = "config",   ArgumentType = ArgumentType.Required,   Flag = IntPtr.Zero,     Value = 'c' },
-                new Option { Name = "version",  ArgumentType = ArgumentType.None,       Flag = IntPtr.Zero,     Value = 'v' }
+                new Option { Name = "help",     ArgumentType = ArgumentType.None,           Value = 'h' },
+                new Option { Name = "config",   ArgumentType = ArgumentType.Required,       Value = 'c' },
+                new Option { Name = "version",  ArgumentType = ArgumentType.None,           Value = 'v' }
             };
             opt.ShortOpts = "hv"; // intentionally leaving out config to test fallbar to long opts
             opt.AppArgs = new[] { "-hv", "-ctest" };
@@ -128,9 +128,9 @@ namespace getopt.net.tests {
         public void TestGetNextOptShort_AllOptsInSameString() {
             var opt = new GetOpt();
             opt.Options = new[] {
-                new Option { Name = "help",     ArgumentType = ArgumentType.None,       Flag = IntPtr.Zero,     Value = 'h' },
-                new Option { Name = "config",   ArgumentType = ArgumentType.Required,   Flag = IntPtr.Zero,     Value = 'c' },
-                new Option { Name = "version",  ArgumentType = ArgumentType.None,       Flag = IntPtr.Zero,     Value = 'v' }
+                new Option { Name = "help",     ArgumentType = ArgumentType.None,           Value = 'h' },
+                new Option { Name = "config",   ArgumentType = ArgumentType.Required,       Value = 'c' },
+                new Option { Name = "version",  ArgumentType = ArgumentType.None,           Value = 'v' }
             };
             opt.ShortOpts = "hvc:"; // intentionally leaving out config to test fallbar to long opts
             opt.AppArgs = new[] { "-hvctest" };
@@ -169,12 +169,12 @@ namespace getopt.net.tests {
         public void TestGetNextOptShort_MultipleOptsAndArgs() {
             var opt = new GetOpt();
             opt.Options = new[] {
-                new Option { Name = "config",           ArgumentType = ArgumentType.Required,   Flag = IntPtr.Zero, Value = 'c' },
-                new Option { Name = "log-lvl",          ArgumentType = ArgumentType.Required,   Flag = IntPtr.Zero, Value = 'L' },
-                new Option { Name = "help",             ArgumentType = ArgumentType.None,       Flag = IntPtr.Zero, Value = 'h' },
-                new Option { Name = "version",          ArgumentType = ArgumentType.None,       Flag = IntPtr.Zero, Value = 'v' },
-                new Option { Name = "check-updates",    ArgumentType = ArgumentType.None,       Flag = IntPtr.Zero, Value = 'U' },
-                new Option { Name = "reset-cfg",        ArgumentType = ArgumentType.Optional,   Flag = IntPtr.Zero, Value = '%' }
+                new Option { Name = "config",           ArgumentType = ArgumentType.Required,   Value = 'c' },
+                new Option { Name = "log-lvl",          ArgumentType = ArgumentType.Required,   Value = 'L' },
+                new Option { Name = "help",             ArgumentType = ArgumentType.None,       Value = 'h' },
+                new Option { Name = "version",          ArgumentType = ArgumentType.None,       Value = 'v' },
+                new Option { Name = "check-updates",    ArgumentType = ArgumentType.None,       Value = 'U' },
+                new Option { Name = "reset-cfg",        ArgumentType = ArgumentType.Optional,   Value = '%' }
                 // add more as required
             };
             opt.ShortOpts = "c:L:hv%U";

--- a/getopt.net/Option.cs
+++ b/getopt.net/Option.cs
@@ -17,25 +17,10 @@ namespace getopt.net {
 		/// </summary>
 		/// <param name="name">The name of the argument.</param>
 		/// <param name="argType">The argument type.</param>
-		/// <param name="flag">The flag.</param>
-		/// <param name="value">The value of the option.</param>
-		public Option(string name, ArgumentType argType, IntPtr flag, char value) {
-			Name = name;
-			ArgumentType = argType;
-			Flag = flag;
-			Value = value;
-		}
-
-		/// <summary>
-		/// Constructs a new instance of this struct.
-		/// </summary>
-		/// <param name="name">The name of the argument.</param>
-		/// <param name="argType">The argument type.</param>
 		/// <param name="value">The value of the option.</param>
 		public Option(string name, ArgumentType argType, char value) {
 			Name = name;
 			ArgumentType = argType;
-			Flag = IntPtr.Zero;
 			Value = value;
 		}
 

--- a/getopt.net/Option.cs
+++ b/getopt.net/Option.cs
@@ -56,14 +56,6 @@ namespace getopt.net {
 		public ArgumentType? ArgumentType { get; set; }
 
 		/// <summary>
-		/// An (optional) pointer to a flag variable to set.
-		/// </summary>
-		/// <remarks >
-		/// If set, Flag must point to a char type!
-		/// </remarks>
-		public IntPtr Flag { get; set; }
-
-		/// <summary>
 		/// The value (short opt) for the option.
 		/// </summary>
 		public char Value { get; set; }

--- a/getopt.net/getopt.net.csproj
+++ b/getopt.net/getopt.net.csproj
@@ -14,8 +14,7 @@ GitHub: https://github.com/SimonCahill/getopt.net</Description>
     <PackageId>getopt.net-bsd</PackageId>
     <PublisherName>Simon Cahill</PublisherName>
     <SupportUrl>https://docs.simonc.eu/docs/getopt.net</SupportUrl>
-    <ReleaseVersion>0.3.1</ReleaseVersion>
-    <Version>0.3.1</Version>
+    <ReleaseVersion>0.4.0</ReleaseVersion>
     <SynchReleaseVersion>true</SynchReleaseVersion>
     <RepositoryUrl>https://github.com/SimonCahill/getopt.net</RepositoryUrl>
     <PackageProjectUrl>https://docs.simonc.eu/docs/getopt.net</PackageProjectUrl>
@@ -23,13 +22,15 @@ GitHub: https://github.com/SimonCahill/getopt.net</Description>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
-    <Version>0.3.1</Version>
+    <Version>0.4.0</Version>
     <PackageTags>getopt; getopt.net; argument-parsing; parser; arguments; options; getopt_long</PackageTags>
-    <PackageReleaseNotes>This is a minor release related to #11.
+    <PackageReleaseNotes>
+This release introduces a potentially breaking change!
 
 # Changes:
- - DoubleDashStopsParsing is now default true.
- - Bumped up version to 0.3.1</PackageReleaseNotes>
+ - Removed support for Flag parameter in Options struct.
+ - Bumped up version to 0.4.0
+    </PackageReleaseNotes>
     <Title>getopt.net</Title>
     <PackageRequireLicenseAcceptance>True</PackageRequireLicenseAcceptance>
 


### PR DESCRIPTION
This release introduces a potentially breaking change!

# Changes:
 - Removed support for Flag parameter in Options struct.
 - Bumped up version to 0.4.0