### PR TITLE
Add windows arg convention support

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "dotnet-test-explorer.autoWatch": true
+}

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ There are several methods of installing and using getopt.net in your project.
 
 # Features
 
-### Full support for getopt-like command-line options:
+### Full support for getopt-like command-line options
 
  - `--long-opts`
  - `--long-opts=with_options`
@@ -30,6 +30,16 @@ There are several methods of installing and using getopt.net in your project.
  - `-ShortOpTs`
  - `-ShortsWithOpTi0n5`
  - `-s with_opts`
+
+### Support for options using the Windows convention
+
+ - `/h` (short opts)
+ - `/long-opts`
+ - `/hxcfsdf` (GNU-style short opts!)
+ - `/long-opts:with-win-style-args`
+ - `/long-opts with-args-separated-by-space`
+ - `/long-opts=with-posix-separator`
+ - `/fmyfile` (short opts with parameters!)
 
 ### The standard getopt shortopt-string format is supported:
 ```csharp
@@ -80,6 +90,7 @@ static void Main(string[] args) {
         ShortOpts = "hvc:",
         AppArgs = args, // REQUIRED
         OnlyShortOpts = false,
+        // AllowWindowsConventions = true, // enable this for Windows-style options
         // other options here
     };
 
@@ -115,7 +126,8 @@ module Program
         Dim getopt = New GetOpt With {
             .AppArgs = args,
             .Options = _progOptions,
-            .ShortOpts = _progShortOptions
+            .ShortOpts = _progShortOptions,
+            ' .AllowWindowsConventions = true ' enable me for Windows-style options!
         }
 
         Dim optChar = 0

--- a/getopt.net.tests/GetOptTests_Inherited.cs
+++ b/getopt.net.tests/GetOptTests_Inherited.cs
@@ -62,6 +62,31 @@
             Assert.AreEqual("shortopt", StripDashes(false));
         }
 
+
+
+        [TestMethod]
+        public void TestHasArgumentInOption_HasArgs() {
+            m_currentIndex = 0;
+            AppArgs = new[] {
+                // GNU/POSIX style
+                "--has arg", "--has=arg"
+            };
+
+            Assert.IsTrue(HasArgumentInOption(out var optName, out var optVal));
+            Assert.IsNotNull(optName);
+            Assert.AreEqual("--has", optName);
+            Assert.IsNotNull(optVal);
+            Assert.AreEqual("arg", optVal);
+
+            m_currentIndex++; // manually increment counter
+
+            Assert.IsTrue(HasArgumentInOption(out optName, out optVal));
+            Assert.IsNotNull(optName);
+            Assert.AreEqual("--has", optName);
+            Assert.IsNotNull(optVal);
+            Assert.AreEqual("arg", optVal);
+        }
+
     }
 
 }

--- a/getopt.net.tests/GetOptTests_Inherited.cs
+++ b/getopt.net.tests/GetOptTests_Inherited.cs
@@ -18,13 +18,13 @@
             var invalidArg2 = "c:";
             var invalidArg3 = "--hvc:";
 
-            Assert.IsTrue(IsShortOption(ref validArg1));
-            Assert.IsTrue(IsShortOption(ref validArg2));
-            Assert.IsTrue(IsShortOption(ref validArg3));
+            Assert.IsTrue(IsShortOption(validArg1));
+            Assert.IsTrue(IsShortOption(validArg2));
+            Assert.IsTrue(IsShortOption(validArg3));
 
-            Assert.IsFalse(IsShortOption(ref invalidArg1));
-            Assert.IsFalse(IsShortOption(ref invalidArg2));
-            Assert.IsFalse(IsShortOption(ref invalidArg3));
+            Assert.IsFalse(IsShortOption(invalidArg1));
+            Assert.IsFalse(IsShortOption(invalidArg2));
+            Assert.IsFalse(IsShortOption(invalidArg3));
         }
 
         [TestMethod]
@@ -38,14 +38,14 @@
             var invalidArg3 = "config=test";
             var invalidArg4 = "config --test";
 
-            Assert.IsTrue(IsLongOption(ref validArg1));
-            Assert.IsTrue(IsLongOption(ref validArg2));
-            Assert.IsTrue(IsLongOption(ref validArg3));
+            Assert.IsTrue(IsLongOption(validArg1));
+            Assert.IsTrue(IsLongOption(validArg2));
+            Assert.IsTrue(IsLongOption(validArg3));
 
-            Assert.IsFalse(IsLongOption(ref invalidArg1));
-            Assert.IsFalse(IsLongOption(ref invalidArg2));
-            Assert.IsFalse(IsLongOption(ref invalidArg3));
-            Assert.IsFalse(IsLongOption(ref invalidArg4));
+            Assert.IsFalse(IsLongOption(invalidArg1));
+            Assert.IsFalse(IsLongOption(invalidArg2));
+            Assert.IsFalse(IsLongOption(invalidArg3));
+            Assert.IsFalse(IsLongOption(invalidArg4));
         }
 
         [TestMethod]
@@ -58,6 +58,8 @@
 
             AppArgs = new[] { "--double-dash" };
             Assert.AreEqual("double-dash", StripDashes(true));
+            AppArgs = new[] { "-shortopt" };
+            Assert.AreEqual("shortopt", StripDashes(false));
         }
 
     }

--- a/getopt.net.tests/GetOptTests_Inherited_WindowsConventions.cs
+++ b/getopt.net.tests/GetOptTests_Inherited_WindowsConventions.cs
@@ -50,9 +50,92 @@ namespace getopt.net.tests {
 
             AppArgs = new[] { "/long-option" };
             Assert.AreEqual("long-option", StripDashes(true));
-            
+
             AppArgs = new[] { "/shortopt" };
             Assert.AreEqual("shortopt", StripDashes(false));
+        }
+
+        [TestMethod]
+        public void TestHasArgumentInOption_NoArgs() {
+            m_currentIndex = 0; // ensure we always start at first index
+            AppArgs = new[] {
+                // no arguments here
+                "/noarg", "-c", "--noarg"
+            };
+
+            Assert.IsFalse(HasArgumentInOption(out var optName, out var optVal));
+            Assert.IsNotNull(optName);
+            Assert.AreEqual("noarg", optName);
+            Assert.IsNull(optVal);
+
+            m_currentIndex++; // manually increment counter
+
+            Assert.IsFalse(HasArgumentInOption(out optName, out optVal));
+            Assert.IsNotNull(optName);
+            Assert.AreEqual("c", optName);
+            Assert.IsNull(optVal);
+
+            m_currentIndex++;
+
+            Assert.IsFalse(HasArgumentInOption(out optName, out optVal));
+            Assert.IsNotNull(optName);
+            Assert.AreEqual("noarg", optName);
+            Assert.IsNull(optVal);
+
+        }
+        
+        [TestMethod]
+        public void TestHasArgumentInOption_WinStyleArgs() {
+            m_currentIndex = 0;
+            AppArgs = new[] {
+                // Windows style
+                "/has:arg", "/has arg", "/has=arg",
+            };
+
+            Assert.IsTrue(HasArgumentInOption(out var optName, out var optVal));
+            Assert.IsNotNull(optName);
+            Assert.AreEqual("/has", optName);
+            Assert.IsNotNull(optVal);
+            Assert.AreEqual("arg", optVal);
+
+            m_currentIndex++; // manually increment counter
+
+            Assert.IsTrue(HasArgumentInOption(out optName, out optVal));
+            Assert.IsNotNull(optName);
+            Assert.AreEqual("/has", optName);
+            Assert.IsNotNull(optVal);
+            Assert.AreEqual("arg", optVal);
+
+            m_currentIndex++;
+
+            Assert.IsTrue(HasArgumentInOption(out optName, out optVal));
+            Assert.IsNotNull(optName);
+            Assert.AreEqual("/has", optName);
+            Assert.IsNotNull(optVal);
+            Assert.AreEqual("arg", optVal);
+        }
+
+        [TestMethod]
+        public void TestHasArgumentInOption_GnuPosixStyleArgs() {
+            m_currentIndex = 0;
+            AppArgs = new[] {
+                // GNU/POSIX style
+                "--has arg", "--has=arg"
+            };
+
+            Assert.IsTrue(HasArgumentInOption(out var optName, out var optVal));
+            Assert.IsNotNull(optName);
+            Assert.AreEqual("--has", optName);
+            Assert.IsNotNull(optVal);
+            Assert.AreEqual("arg", optVal);
+
+            m_currentIndex++; // manually increment counter
+
+            Assert.IsTrue(HasArgumentInOption(out optName, out optVal));
+            Assert.IsNotNull(optName);
+            Assert.AreEqual("--has", optName);
+            Assert.IsNotNull(optVal);
+            Assert.AreEqual("arg", optVal);
         }
 
     }

--- a/getopt.net.tests/GetOptTests_Inherited_WindowsConventions.cs
+++ b/getopt.net.tests/GetOptTests_Inherited_WindowsConventions.cs
@@ -1,0 +1,60 @@
+using System;
+
+namespace getopt.net.tests {
+
+    [TestClass]
+    public class GetOptTests_Inherited_Windows: GetOpt {
+
+        public GetOptTests_Inherited_Windows() {
+            AllowWindowsConventions = true;
+            Options = new[] {
+                new Option("windowsarg", ArgumentType.None, 'w'),
+                new Option("AnotherWindowsArg", ArgumentType.None, 'A')
+            };
+        }
+
+        [TestMethod]
+        public void TestIsLongOption() {
+            Assert.IsTrue(IsLongOption("/windowsarg"));
+            Assert.IsTrue(IsLongOption("/AnotherWindowsArg"));
+            Assert.IsFalse(IsLongOption("/a"));
+            Assert.IsTrue(IsLongOption("--posix-like"));
+        }
+
+        [TestMethod]
+        public void TestIsShortOption() {
+            Assert.IsTrue(IsShortOption("/w"));
+            Assert.IsTrue(IsShortOption("/W"));
+            Assert.IsTrue(IsShortOption("/0"));
+            Assert.IsFalse(IsShortOption(":m"));
+            Assert.IsFalse(IsShortOption("O"));
+            Assert.IsTrue(IsShortOption("-c"));
+        }
+
+        [TestMethod]
+        public void TestStripDashes() {
+            AppArgs = new[] { "no-dashes-or-slahes" };
+            Assert.AreEqual("no-dashes-or-slahes", StripDashes(true));
+
+            AppArgs = new[] { "-single-dash" };
+            Assert.AreEqual("single-dash", StripDashes(true));
+
+            AppArgs = new[] { "--double-dash" };
+            Assert.AreEqual("double-dash", StripDashes(true));
+
+            AppArgs = new[] { "-shortopt" };
+            Assert.AreEqual("shortopt", StripDashes(false));
+
+            AppArgs = new[] { "/single-slash" };
+            Assert.AreEqual("single-slash", StripDashes(true));
+
+            AppArgs = new[] { "/long-option" };
+            Assert.AreEqual("long-option", StripDashes(true));
+            
+            AppArgs = new[] { "/shortopt" };
+            Assert.AreEqual("shortopt", StripDashes(false));
+        }
+
+    }
+
+}

--- a/getopt.net.tests/GetOptTests_RealWorld_Windows.cs
+++ b/getopt.net.tests/GetOptTests_RealWorld_Windows.cs
@@ -1,0 +1,478 @@
+using System;
+
+namespace getopt.net.tests {
+
+    [TestClass]
+    public class GetOptTests_RealWorld_Windows {
+
+        [TestMethod]
+        public void TestGetNextOptLong() {
+            var opt = new GetOpt();
+            opt.AppArgs = new[] { "/help" };
+            opt.Options = new[] { new Option { Name = "help", ArgumentType = ArgumentType.None, Value = 'h' } };
+            opt.AllowWindowsConventions = true;
+
+            string? optArg = "";
+            char optChar = (char)opt.GetNextOpt(out optArg);
+            Assert.AreEqual('h', optChar);
+            Assert.AreEqual(null, optArg);
+        }
+
+        [TestMethod]
+        public void TestGetNextOptLongWithRequiredArg_SeperatedByEquals() {
+            var opt = new GetOpt();
+            opt.AppArgs = new[] { "/test=test" };
+            opt.Options = new[] { new Option { Name = "test", ArgumentType = ArgumentType.Required, Value = 't' } };
+            opt.AllowWindowsConventions = true;
+
+            string? optArg = "";
+            char optChar = (char)opt.GetNextOpt(out optArg);
+            Assert.AreEqual('t', optChar);
+            Assert.AreEqual("test", optArg);
+        }
+
+        [TestMethod]
+        public void TestGetNextOptLongWithRequiredArgs_SeparatedBySpace() {
+            var opt = new GetOpt();
+            opt.AppArgs = new[] { "/test test" };
+            opt.Options = new[] { new Option { Name = "test", ArgumentType = ArgumentType.Required, Value = 't' } };
+            opt.AllowWindowsConventions = true;
+
+            string? optArg = "";
+            char optChar = (char)opt.GetNextOpt(out optArg);
+            Assert.AreEqual('t', optChar);
+            Assert.AreEqual("test", optArg);
+        }
+
+        [TestMethod]
+        public void TestGetNextOptLongWithRequiredArgs_SeparatedByArg() {
+            var opt = new GetOpt();
+            opt.AppArgs = new[] { "/test", "test" };
+            opt.Options = new[] { new Option { Name = "test", ArgumentType = ArgumentType.Required, Value = 't' } };
+            opt.AllowWindowsConventions = true;
+
+            string? optArg = "";
+            char optChar = (char)opt.GetNextOpt(out optArg);
+            Assert.AreEqual('t', optChar);
+            Assert.AreEqual("test", optArg);
+        }
+
+        [TestMethod]
+        public void TestGetNextOptLongWithMultipleArgs() {
+            var opt = new GetOpt();
+            opt.AppArgs = new[] { "/test", "test", "/test2", "/test3=test3", "/test4 test4" };
+            opt.Options = new[] {
+                new Option { Name = "test",     ArgumentType = ArgumentType.Required,   Value = 't' },
+                new Option { Name = "test2",    ArgumentType = ArgumentType.None,       Value = '1' },
+                new Option { Name = "test3",    ArgumentType = ArgumentType.Optional,   Value = '2' },
+                new Option { Name = "test4",    ArgumentType = ArgumentType.Required,   Value = '3' }
+            };
+            opt.AllowWindowsConventions = true;
+
+            char optChar = (char)opt.GetNextOpt(out string? optArg);
+            Assert.AreEqual('t', optChar);
+            Assert.AreEqual("test", optArg);
+
+            optChar = (char)opt.GetNextOpt(out optArg);
+            Assert.AreEqual('1', optChar);
+            Assert.AreEqual(null, optArg);
+
+            optChar = (char)opt.GetNextOpt(out optArg);
+            Assert.AreEqual('2', optChar);
+            Assert.AreEqual("test3", optArg);
+
+            optChar = (char)opt.GetNextOpt(out optArg);
+            Assert.AreEqual('3', optChar);
+            Assert.AreEqual("test4", optArg);
+        }
+
+        [TestMethod]
+        public void TestGetNextOptShort_WithoutLongOpts() {
+            var opt = new GetOpt();
+            opt.ShortOpts = "hc:v";
+            opt.AppArgs = new[] { "/h", "/ctest", "/v" };
+            opt.AllowWindowsConventions = true;
+
+            var optChar = (char)opt.GetNextOpt(out var optArg);
+            Assert.AreEqual('h', optChar);
+            Assert.AreEqual(null, optArg);
+
+            optChar = (char)opt.GetNextOpt(out optArg);
+            Assert.AreEqual('c', optChar);
+            Assert.AreEqual("test", optArg);
+
+            optChar = (char)opt.GetNextOpt(out optArg);
+            Assert.AreEqual('v', optChar);
+            Assert.AreEqual(null, optArg);
+        }
+
+        [TestMethod]
+        public void TestGetNextOptShort_WithFallbackToLongOpt() {
+            var opt = new GetOpt();
+            opt.Options = new[] {
+                new Option { Name = "help",     ArgumentType = ArgumentType.None,           Value = 'h' },
+                new Option { Name = "config",   ArgumentType = ArgumentType.Required,       Value = 'c' },
+                new Option { Name = "version",  ArgumentType = ArgumentType.None,           Value = 'v' }
+            };
+            opt.ShortOpts = "hv"; // intentionally leaving out config to test fallbar to long opts
+            opt.AppArgs = new[] { "/hv", "/ctest" };
+            opt.AllowWindowsConventions = true;
+
+            var optChar = (char)opt.GetNextOpt(out var optArg);
+            Assert.AreEqual('h', optChar);
+            Assert.IsNull(optArg);
+
+            optChar = (char)opt.GetNextOpt(out optArg);
+            Assert.AreEqual('v', optChar);
+            Assert.IsNull(optArg);
+
+            optChar = (char)opt.GetNextOpt(out optArg);
+            Assert.AreEqual('c', optChar);
+            Assert.AreEqual("test", optArg);
+        }
+
+        [TestMethod]
+        public void TestGetNextOptShort_AllOptsInSameString() {
+            var opt = new GetOpt();
+            opt.Options = new[] {
+                new Option { Name = "help",     ArgumentType = ArgumentType.None,           Value = 'h' },
+                new Option { Name = "config",   ArgumentType = ArgumentType.Required,       Value = 'c' },
+                new Option { Name = "version",  ArgumentType = ArgumentType.None,           Value = 'v' }
+            };
+            opt.ShortOpts = "hvc:"; // intentionally leaving out config to test fallbar to long opts
+            opt.AppArgs = new[] { "/hvctest" };
+            opt.AllowWindowsConventions = true;
+
+            var optChar = (char)opt.GetNextOpt(out var optArg);
+            Assert.AreEqual('h', optChar);
+            Assert.IsNull(optArg);
+
+            optChar = (char)opt.GetNextOpt(out optArg);
+            Assert.AreEqual('v', optChar);
+            Assert.IsNull(optArg);
+
+            optChar = (char)opt.GetNextOpt(out optArg);
+            Assert.AreEqual('c', optChar);
+            Assert.AreEqual("test", optArg);
+        }
+
+        [TestMethod]
+        public void TestGetNextOptShort_AllOptsInSameString_WithErrors_NoException() {
+            var opt = new GetOpt();
+            opt.ShortOpts = "t";
+            opt.Options = Array.Empty<Option>();
+            opt.AppArgs = new[] { "/te" };
+            opt.IgnoreInvalidOptions = true;
+            opt.AllowWindowsConventions = true;
+
+            var optChar = (char)opt.GetNextOpt(out var optArg);
+            Assert.AreEqual('t', optChar);
+            Assert.IsNull(optArg);
+
+            optChar = (char)opt.GetNextOpt(out optArg);
+            Assert.AreEqual(GetOpt.InvalidOptChar, optChar);
+            Assert.IsNull(optArg);
+        }
+
+        [TestMethod]
+        public void TestGetNextOptShort_MultipleOptsAndArgs() {
+            var opt = new GetOpt();
+            opt.Options = new[] {
+                new Option { Name = "config",           ArgumentType = ArgumentType.Required,   Value = 'c' },
+                new Option { Name = "log-lvl",          ArgumentType = ArgumentType.Required,   Value = 'L' },
+                new Option { Name = "help",             ArgumentType = ArgumentType.None,       Value = 'h' },
+                new Option { Name = "version",          ArgumentType = ArgumentType.None,       Value = 'v' },
+                new Option { Name = "check-updates",    ArgumentType = ArgumentType.None,       Value = 'U' },
+                new Option { Name = "reset-cfg",        ArgumentType = ArgumentType.Optional,   Value = '%' }
+                // add more as required
+            };
+            opt.ShortOpts = "c:L:hv%U";
+            opt.DoubleDashStopsParsing = true;
+            opt.AppArgs = new[] { "/ctest.json", "/Ltrace" };
+            opt.AllowWindowsConventions = true;
+
+            var optChar = (char)opt.GetNextOpt(out var optArg);
+            Assert.AreEqual('c', optChar);
+            Assert.IsNotNull(optArg);
+            Assert.AreEqual("test.json", optArg);
+
+            optChar = (char)opt.GetNextOpt(out optArg);
+            Assert.AreEqual('L', optChar);
+            Assert.IsNotNull(optArg);
+            Assert.AreEqual("trace", optArg);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ParseException))]
+        public void TestFilenameOnly_ExpectException() {
+            var opt = new GetOpt();
+            opt.ShortOpts = string.Empty;
+            opt.Options = Array.Empty<Option>();
+            opt.AppArgs = new[] { "filename.txt" };
+            opt.IgnoreInvalidOptions = false;
+            opt.AllowWindowsConventions = true;
+
+            opt.GetNextOpt(out var _); // Something expressing the existence of filename.txt should happen here.
+        }
+
+        [TestMethod]
+        public void TestFilenameOnly_IgnoreInvalidOpts() {
+            var opt = new GetOpt();
+            opt.ShortOpts = string.Empty;
+            opt.Options = Array.Empty<Option>();
+            opt.AppArgs = new[] { "filename.txt" };
+            opt.AllowWindowsConventions = true;
+            string? optArg;
+            Assert.AreEqual(GetOpt.InvalidOptChar, (char)opt.GetNextOpt(out optArg));
+        }
+
+        [TestMethod]
+        public void TestFilenameWithPreceedingDashes() {
+            var opt = new GetOpt();
+            opt.ShortOpts = string.Empty;
+            opt.Options = Array.Empty<Option>();
+            opt.DoubleDashStopsParsing = true;
+            opt.AppArgs = new[] { "--", "/filename.txt" };
+            opt.AllowWindowsConventions = true;
+            Assert.AreEqual(1, opt.GetNextOpt(out var _));
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ParseException))]
+        public void TestOptionBeforeFilename_ExpectException() {
+            var opt = new GetOpt();
+            opt.ShortOpts = "t";
+            opt.Options = Array.Empty<Option>();
+            opt.AppArgs = new[] { "/t", "filename.txt" };
+            opt.IgnoreInvalidOptions = false;
+            opt.AllowWindowsConventions = true;
+
+            var optChar = (char)opt.GetNextOpt(out var optArg);
+            Assert.AreEqual('t', optChar);
+            Assert.IsNull(optArg);
+            opt.GetNextOpt(out var _); // Something expressing the existence of filename.txt should happen here.
+        }
+
+        [TestMethod]
+        public void TestOptionBeforeFilename_IgnoreInvalidOpts() {
+            var opt = new GetOpt();
+            opt.ShortOpts = "t";
+            opt.Options = Array.Empty<Option>();
+            opt.AppArgs = new[] { "/t", "filename.txt" };
+            opt.IgnoreInvalidOptions = true;
+            opt.AllowWindowsConventions = true;
+
+            var optChar = (char)opt.GetNextOpt(out var optArg);
+            Assert.AreEqual('t', optChar);
+            Assert.IsNull(optArg);
+            optChar = (char)opt.GetNextOpt(out optArg);
+            Assert.AreEqual(GetOpt.InvalidOptChar, optChar);
+            Assert.IsNotNull(optArg);
+            Assert.AreEqual("filename.txt", optArg);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ParseException))]
+        public void TestFilenameBeforeOptionGnuParsing_ExpectException() {
+            var opt = new GetOpt();
+            opt.ShortOpts = "t";
+            opt.Options = Array.Empty<Option>();
+            opt.AppArgs = new[] { "filename.txt", "/t" };
+            opt.IgnoreInvalidOptions = false;
+            opt.AllowWindowsConventions = true;
+
+            var optChar = (char)opt.GetNextOpt(out var optArg);
+            Assert.AreEqual('t', optChar);
+            Assert.IsNull(optArg);
+            opt.GetNextOpt(out var _); // Something expressing the existence of filename.txt should happen here.
+        }
+
+        [TestMethod]
+        public void TestFilenameBeforeOptionGnuInOrderParsing() {
+            var opt = new GetOpt();
+            opt.ShortOpts = "-t";
+            opt.Options = Array.Empty<Option>();
+            opt.AppArgs = new[] { "filename.txt", "/t" };
+            opt.IgnoreInvalidOptions = true;
+            opt.AllowWindowsConventions = true;
+
+            var optChar = (char)opt.GetNextOpt(out var optArg);
+            Assert.AreEqual(GetOpt.NonOptChar, optChar);
+            Assert.IsNotNull(optArg);
+            Assert.AreEqual("filename.txt", optArg);
+
+            optChar = (char)opt.GetNextOpt(out optArg);
+            Assert.AreEqual('t', optChar);
+            Assert.IsNull(optArg);
+        }
+
+        [TestMethod]
+        public void TestFilenameBeforeOptionPosixParsing() {
+            var opt = new GetOpt();
+            opt.ShortOpts = "t";
+            opt.Options = Array.Empty<Option>();
+            opt.AppArgs = new[] { "filename.txt", "/t" };
+            opt.IgnoreInvalidOptions = true;
+            opt.AllowWindowsConventions = true;
+
+            var optChar = (char)opt.GetNextOpt(out var optArg);
+            Assert.AreEqual(GetOpt.InvalidOptChar, optChar);
+            Assert.IsNotNull(optArg);
+            Assert.AreEqual("filename.txt", optArg);
+
+            optChar = (char)opt.GetNextOpt(out optArg);
+            Assert.AreEqual('t', optChar);
+            Assert.IsNull(optArg);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ParseException))]
+        public void TestFilenameBeforeOptionPosixParsing_ExpectException() {
+            var opt = new GetOpt();
+            opt.ShortOpts = "t";
+            opt.Options = Array.Empty<Option>();
+            opt.AppArgs = new[] { "filename.txt", "/t" };
+            opt.IgnoreInvalidOptions = false;
+            opt.AllowWindowsConventions = true;
+
+            var optChar = (char)opt.GetNextOpt(out var optArg);
+            optChar = (char)opt.GetNextOpt(out optArg);
+        }
+
+        [TestMethod]
+        public void TestDoubleDashStopsParsing_True() {
+            var opt = new GetOpt {
+                AppArgs = new[] { "/hcv", "--", "/test", "/xzf" },
+                DoubleDashStopsParsing = true, // this is true by default
+                Options = new Option[] {
+                    new Option("help", ArgumentType.None, 'h'),
+                    new Option("config", ArgumentType.Optional, 'c'),
+                    new Option("verbose", ArgumentType.None, 'v'),
+                    new Option("test", ArgumentType.None, 't'),
+                    new Option("extract", ArgumentType.None, 'x'),
+                    new Option("zip", ArgumentType.None, 'z'),
+                    new Option("find", ArgumentType.None, 'f')
+                }
+            };
+            opt.AllowWindowsConventions = true;
+
+            var optChar = (char)opt.GetNextOpt(out var optArg);
+            Assert.AreEqual('h', optChar);
+            Assert.IsNull(optArg);
+
+            optChar = (char)opt.GetNextOpt(out optArg);
+            Assert.AreEqual('c', optChar);
+            Assert.IsNull(optArg);
+
+            optChar = (char)opt.GetNextOpt(out optArg);
+            Assert.AreEqual('v', optChar);
+            Assert.IsNull(optArg);
+
+            // At this point, "--" should be encountered.
+            // This is ignored and the next option is returned via optArg.
+            // optChar should == 1
+
+            optChar = (char)opt.GetNextOpt(out optArg);
+            Assert.AreEqual(GetOpt.NonOptChar, optChar);
+            Assert.IsNotNull(optArg);
+            Assert.AreEqual("/test", optArg);
+
+            optChar = (char)opt.GetNextOpt(out optArg);
+            Assert.AreEqual(GetOpt.NonOptChar, optChar);
+            Assert.IsNotNull(optArg);
+            Assert.AreEqual("/xzf", optArg);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ParseException))]
+        public void TestDoubleDashStopsParsing_and_IgnoreInvalidOptions_False() {
+            var opt = new GetOpt {
+                AppArgs = new[] { "/hcv", "--", "/test", "/xzf" },
+                DoubleDashStopsParsing = false, // this is true by default
+                IgnoreInvalidOptions = false, // this is default true
+                Options = new Option[] {
+                    new Option("help", ArgumentType.None, 'h'),
+                    new Option("config", ArgumentType.Optional, 'c'),
+                    new Option("verbose", ArgumentType.None, 'v'),
+                    new Option("test", ArgumentType.None, 't'),
+                    new Option("extract", ArgumentType.None, 'x'),
+                    new Option("zip", ArgumentType.None, 'z'),
+                    new Option("find", ArgumentType.None, 'f')
+                }
+            };
+            opt.AllowWindowsConventions = true;
+
+            var optChar = (char)opt.GetNextOpt(out var optArg);
+            Assert.AreEqual('h', optChar);
+            Assert.IsNull(optArg);
+
+            optChar = (char)opt.GetNextOpt(out optArg);
+            Assert.AreEqual('c', optChar);
+            Assert.IsNull(optArg);
+
+            optChar = (char)opt.GetNextOpt(out optArg);
+            Assert.AreEqual('v', optChar);
+            Assert.IsNull(optArg);
+
+            // At this point, "--" should be encountered.
+            // This is will throw an exception if "IgnoreInvalidOptions" is false
+            optChar = (char)opt.GetNextOpt(out optArg);
+        }
+
+        [TestMethod]
+        public void TestDoubleDashStopsParsing_False() {
+            var opt = new GetOpt {
+                AppArgs = new[] { "/hcv", "--", "/test", "/xzf" },
+                DoubleDashStopsParsing = false, // this is true by default
+                Options = new Option[] {
+                    new Option("help", ArgumentType.None, 'h'),
+                    new Option("config", ArgumentType.Optional, 'c'),
+                    new Option("verbose", ArgumentType.None, 'v'),
+                    new Option("test", ArgumentType.None, 't'),
+                    new Option("extract", ArgumentType.None, 'x'),
+                    new Option("zip", ArgumentType.None, 'z'),
+                    new Option("find", ArgumentType.None, 'f')
+                }
+            };
+            opt.AllowWindowsConventions = true;
+
+            var optChar = (char)opt.GetNextOpt(out var optArg);
+            Assert.AreEqual('h', optChar);
+            Assert.IsNull(optArg);
+
+            optChar = (char)opt.GetNextOpt(out optArg);
+            Assert.AreEqual('c', optChar);
+            Assert.IsNull(optArg);
+
+            optChar = (char)opt.GetNextOpt(out optArg);
+            Assert.AreEqual('v', optChar);
+            Assert.IsNull(optArg);
+
+            // At this point, "--" should be encountered.
+            // This is an invalid option and GetNextOpt should
+            // return '?'
+
+            optChar = (char)opt.GetNextOpt(out optArg);
+            Assert.AreEqual(GetOpt.InvalidOptChar, optChar);
+            Assert.IsNotNull(optArg);
+            Assert.AreEqual("--", optArg);
+
+            optChar = (char)opt.GetNextOpt(out optArg);
+            Assert.AreEqual('t', optChar);
+            Assert.IsNull(optArg);
+
+            optChar = (char)opt.GetNextOpt(out optArg);
+            Assert.AreEqual('x', optChar);
+            Assert.IsNull(optArg);
+
+            optChar = (char)opt.GetNextOpt(out optArg);
+            Assert.AreEqual('z', optChar);
+            Assert.IsNull(optArg);
+
+            optChar = (char)opt.GetNextOpt(out optArg);
+            Assert.AreEqual('f', optChar);
+            Assert.IsNull(optArg);
+        }
+    }
+
+}

--- a/getopt.net/GetOpt.cs
+++ b/getopt.net/GetOpt.cs
@@ -494,7 +494,7 @@ namespace getopt.net {
                 arg.Length > 1          &&
                 arg[0] == SingleSlash   &&
                 Options.Length != 0     &&
-                Options.Any(o => o.Name == arg.Substring(1)) // We only need this option when parsing options following Windows' conventions
+                Options.Any(o => o.Name == arg.Split(WinArgSeparator, GnuArgSeparator, ' ').First().Substring(1)) // We only need this option when parsing options following Windows' conventions
             ) { return true; }
 
             return arg.Length > 2       &&

--- a/getopt.net/GetOpt.cs
+++ b/getopt.net/GetOpt.cs
@@ -124,7 +124,7 @@ namespace getopt.net {
         /// By convention, Windows-like options begin with a slash (/).
         /// Options with arguments are separated by a colon ':'.
         /// </remarks>
-        public bool AllowWindowsConventions { get; set; } = true;
+        public bool AllowWindowsConventions { get; set; } = false;
 
         /// <summary>
         /// Gets the current index of the app arguments being parsed.


### PR DESCRIPTION
Added support for Windows-style command-line arguments.

Want your application to use Windows-style command-line options?
It's now possible with getopt.net!

```
/help, /h
/file:myfile.txt, /fmyfile.txt, /file=myfile.txt, /file myfile.txt
```

are now all valid with getopt.net!