### PR TITLE
Add support for Powershell-style options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # getop.net changelog
 
+# v0.7.0
+
+Version 0.7.0 introduces a non-breaking change which enables support for Powershell-style options!
+Check out the wiki/README for more information!
+
+## Changes
+ - Added support for Powershell-style options!
+
 # v0.6.0
 
 Version 0.6.0 introduces a non-breaking change which enabled support for optional short-opt arguments!

--- a/README.md
+++ b/README.md
@@ -46,10 +46,20 @@ There are several methods of installing and using getopt.net in your project.
  - `/long-opts=with-posix-separator`
  - `/fmyfile` (short opts with parameters!)
 
+### Support for Powershell-style options
+
+ - `-myoption`
+ - `-myoption=argument`
+ - `-myoption:argument` (AllowWindowsConvention must also be enabled!)
+ - `-myoption argument`
+ - `-myoption` `argument`
+
 ### The standard getopt shortopt-string format is supported:
 
-`:` denotes a **required** argument!<br >
-`;` denotes an **optional** argument!<br >
+`:` denotes a **required** argument!
+
+`;` denotes an **optional** argument!
+
 If none of the above is present after a character in `ShortOpts`, then **no argument** is required.
 
 ```csharp

--- a/getopt.net.tests/GetOptTests_RealWorld.cs
+++ b/getopt.net.tests/GetOptTests_RealWorld.cs
@@ -495,5 +495,91 @@ namespace getopt.net.tests {
             Assert.IsNull(optArg);
         }
 
+        [TestMethod]
+        public void TestPowershellConvention_LongOptions() {
+            var getopt = new GetOpt {
+                Options = new[] {
+                    new Option("test", ArgumentType.None, '1'),
+                    new Option("test2", ArgumentType.Optional, '2'),
+                    new Option("test3", ArgumentType.Required, '3')
+                },
+                AllowPowershellConventions = true,
+                AppArgs = new[] { "-test", "-1", "-test2", "-2", "-test2:arg", "-test2=arg", "-test2 arg", "-test2", "arg", "-test3:arg", "-test3=arg", "-test3 arg", "-test3", "arg", "-12", "-3", "arg" }
+            };
+
+            const string testArg = "arg";
+
+            var optChar = (char)getopt.GetNextOpt(out var optArg);
+            Assert.AreEqual('1', optChar);
+            Assert.IsNull(optArg);
+
+            optChar = (char)getopt.GetNextOpt(out optArg);
+            Assert.AreEqual('1', optChar);
+            Assert.IsNull(optArg);
+
+            optChar = (char)getopt.GetNextOpt(out optArg);
+            Assert.AreEqual('2', optChar);
+            Assert.IsNull(optArg);
+
+            optChar = (char)getopt.GetNextOpt(out optArg);
+            Assert.AreEqual('2', optChar);
+            Assert.IsNull(optArg);
+
+            getopt.AllowWindowsConventions = true;
+            optChar = (char)getopt.GetNextOpt(out optArg);
+            Assert.AreEqual('2', optChar);
+            Assert.IsNotNull(optArg);
+            Assert.AreEqual(testArg, optArg);
+
+
+            optChar = (char)getopt.GetNextOpt(out optArg);
+            Assert.AreEqual('2', optChar);
+            Assert.IsNotNull(optArg);
+            Assert.AreEqual(testArg, optArg);
+
+            optChar = (char)getopt.GetNextOpt(out optArg);
+            Assert.AreEqual('2', optChar);
+            Assert.IsNotNull(optArg);
+            Assert.AreEqual(testArg, optArg);
+
+            optChar = (char)getopt.GetNextOpt(out optArg);
+            Assert.AreEqual('2', optChar);
+            Assert.IsNotNull(optArg);
+            Assert.AreEqual(testArg, optArg);
+
+            optChar = (char)getopt.GetNextOpt(out optArg);
+            Assert.AreEqual('3', optChar);
+            Assert.IsNotNull(optArg);
+            Assert.AreEqual(testArg, optArg);
+
+            optChar = (char)getopt.GetNextOpt(out optArg);
+            Assert.AreEqual('3', optChar);
+            Assert.IsNotNull(optArg);
+            Assert.AreEqual(testArg, optArg);
+
+            optChar = (char)getopt.GetNextOpt(out optArg);
+            Assert.AreEqual('3', optChar);
+            Assert.IsNotNull(optArg);
+            Assert.AreEqual(testArg, optArg);
+
+            optChar = (char)getopt.GetNextOpt(out optArg);
+            Assert.AreEqual('3', optChar);
+            Assert.IsNotNull(optArg);
+            Assert.AreEqual(testArg, optArg);
+
+            optChar = (char)getopt.GetNextOpt(out optArg);
+            Assert.AreEqual('1', optChar);
+            Assert.IsNull(optArg);
+
+            optChar = (char)getopt.GetNextOpt(out optArg);
+            Assert.AreEqual('2', optChar);
+            Assert.IsNull(optArg);
+
+            optChar = (char)getopt.GetNextOpt(out optArg);
+            Assert.AreEqual('3', optChar);
+            Assert.IsNotNull(optArg);
+            Assert.AreEqual(testArg, optArg);
+        }
+
     }
 }

--- a/getopt.net/GetOpt.cs
+++ b/getopt.net/GetOpt.cs
@@ -137,6 +137,18 @@ namespace getopt.net {
         public bool AllowWindowsConventions { get; set; } = false;
 
         /// <summary>
+        /// Gets or sets a value indicating whether or not Powershell-style arguments are allowed.
+        /// This option doesn't conflict with the GNU/POSIX or Windows-style argument parsing and is simply an addition.
+        /// </summary>
+        /// <remarks >
+        /// This option is disabled by default.
+        /// 
+        /// Powershell-style arguments are similar to GNU/POSIX long options, however they begin with a single dash (-).
+        /// </remarks>
+        public bool AllowPowershellConventions { get; set; } = false;
+
+
+        /// <summary>
         /// Either enables or disabled exceptions entirely.
         /// For more specific control over exceptions, see the other options provided by GetOpt.
         /// </summary>
@@ -572,6 +584,19 @@ namespace getopt.net {
                 arg[0] == SingleSlash   &&
                 Options.Length != 0     &&
                 Options.Any(o => o.Name == arg.Split(WinArgSeparator, GnuArgSeparator, ' ').First().Substring(1)) // We only need this option when parsing options following Windows' conventions
+            ) { return true; }
+
+            // Check for Powershell-style arguments.
+            // Powershell arguments are weird and extra checks are needed.
+            // Powershell-style arguments would theoretically interfere with short opts,
+            // so a check to determine whether or not the option is found in Options is required.
+            if (
+                AllowPowershellConventions  &&
+                arg.Length > 1              &&
+                arg[0] == SingleDash        &&
+                Options.Length != 0         &&
+                Options.Any(o => o.Name == arg.Split(WinArgSeparator, GnuArgSeparator, ' ').First().Substring(1)) // We only need this when parsing options following Powershell's conventions
+                // This parsing method is really similar to Windows option parsing...
             ) { return true; }
 
             return arg.Length > 2       &&

--- a/getopt.net/getopt.net.csproj
+++ b/getopt.net/getopt.net.csproj
@@ -22,16 +22,16 @@ GitHub: https://github.com/SimonCahill/getopt.net</Description>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
     <!--<ApplicationIcon >../img/getopt.net-icon.ico</ApplicationIcon>-->
-    <Version>0.6.0</Version>
+    <Version>0.7.0</Version>
     <PackageTags>getopt; getopt.net; argument-parsing; parser; arguments; options; getopt_long</PackageTags>
     <PackageReleaseNotes>
-v0.6.0
+v0.7.0
 
-Version 0.6.0 introduces a non-breaking change which enabled support for optional short-opt arguments!
+Version 0.7.0 introduces a non-breaking change which enables support for Powershell-style options!
 Check out the wiki/README for more info!
 
 Changes
-  - Added support for optional short args!
+  - Added support for Powershell-style arguments.
     </PackageReleaseNotes>
     <Title>getopt.net</Title>
     <PackageRequireLicenseAcceptance>True</PackageRequireLicenseAcceptance>


### PR DESCRIPTION
This release adds support for Powershell-style options on the command line.

Powershell-style options use a single dash (`-`) for long options, instead of the Windows-typical single slash (`/`) or the GNU-/POSIX-typical double-dash (`--`).

Powershell-style options **do not** interfere with standard short opt detection and parsing!

To enable Powershell-style option parsing, simply set `AllowPowershellConventions = true` and happy parsing!