### PR TITLE
Added support for param files

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,4 @@
+﻿[*.cs]
+
+# Default severity for analyzer diagnostics with category 'Style'
+dotnet_analyzer_diagnostic.category-Style.severity = none

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # getop.net changelog
 
+# v0.8.0
+
+Version 0.8.0 introduces a non-breaking change which enables support for paramfiles!
+
+Some applications, notably GCC, use paramfiles as a way to pass a large amount of options and arguments to an application.
+Paramfiles are line-separated lists of arguments and can be enabled by setting `AllowParamFiles = true`.
+Each line in the paramfile will be parsed as if it were passed directly to getopt.net!
+To allow Powershell or Windows conventions, you will still need to enable `AllowWindowsConventions` or `AllowPowershellConventions` respectively.
+
+## Changes
+ - Added support for paramfiles
+ - Updated reference implementations
+
 # v0.7.0
 
 Version 0.7.0 introduces a non-breaking change which enables support for Powershell-style options!

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # getop.net changelog
 
+# v0.7.0
+
+Version 0.7.0 introduces a non-breaking change which enables support for Powershell-style options!
+Check out the wiki/README for more information!
+
+## Changes
+ - Added support for Powershell-style options!
+
 # v0.6.0
 
 Version 0.6.0 introduces a non-breaking change which enabled support for optional short-opt arguments!

--- a/README.md
+++ b/README.md
@@ -54,6 +54,17 @@ There are several methods of installing and using getopt.net in your project.
  - `-myoption argument`
  - `-myoption` `argument`
 
+### Support for paramfiles
+
+Some applications, such as GCC, allow passing of paramfile arguments.
+A paramfile is a line-separated text file which contains one option (and argument) per line.
+Each line of the paramfile is parsed as if it were passed to getopt.net directly.
+
+Syntax:
+```
+myapp @/path/to/paramfile
+```
+
 ### The standard getopt shortopt-string format is supported:
 
 `:` denotes a **required** argument!

--- a/README.md
+++ b/README.md
@@ -46,10 +46,20 @@ There are several methods of installing and using getopt.net in your project.
  - `/long-opts=with-posix-separator`
  - `/fmyfile` (short opts with parameters!)
 
+### Support for Powershell-style options
+
+ - `-myoption`
+ - `-myoption=argument`
+ - `-myoption:argument` (AllowWindowsConvention must also be enabled!)
+ - `-myoption argument`
+ - `-myoption` `argument`
+
 ### The standard getopt shortopt-string format is supported:
 
-`:` denotes a **required** argument!<br >
-`;` denotes an **optional** argument!<br >
+`:` denotes a **required** argument!
+
+`;` denotes an **optional** argument!
+
 If none of the above is present after a character in `ShortOpts`, then **no argument** is required.
 
 ```csharp

--- a/getopt.net.reference.cs/Program.cs
+++ b/getopt.net.reference.cs/Program.cs
@@ -1,4 +1,8 @@
-﻿namespace getopt.net.reference.cs {
+﻿using System;
+
+namespace getopt.net.reference.cs {
+
+    using System.IO;
 
     internal class Program {
 

--- a/getopt.net.reference.cs/Program.cs
+++ b/getopt.net.reference.cs/Program.cs
@@ -10,7 +10,10 @@
                     new Option("version",   ArgumentType.None,      'v'),
                     new Option("file",      ArgumentType.Required,  'f')
                 },
-                ShortOpts = "hvf:t;" // the last option isn't an error!
+                ShortOpts = "hvf:t;", // the last option isn't an error!
+                AllowParamFiles = true,
+                AllowWindowsConventions = true,
+                AllowPowershellConventions = true
             };
 
             var optChar = 0;
@@ -60,16 +63,32 @@
                 myapp -f /path/to/file
                 myapp --file=/path/to/file
                 myapp --file /path/to/file
+
+                myapp @/path/to/paramfile # load all args from param file
             
             Arguments:
                 --help,     -h      Displays this menu and exits
+                /help,      /h      Displays this menu and exits (Windows conventions)
+                -help,      -h      Displays this menu and exits (Powershell conventions)
+
                 --version,  -v      Displays the version and exits
+                /version,   /v      Displays the version and exits (Windows conventions)
+                -version,   -v      Displays the version and exits (Powershell conventions)
+
                 --file=<>,  -f<>    Reads the file back to stdout.
+                --file <>,  -f<>    Reads the file back to stdout.
+                --file:<>,  -f<>    Reads the file back to stdout. (Windows arg conventions)
+                /file=<>,   /f<>    Reads the file back to stdout. (Windows opt and GNU/POSIX arg conventions)
+                /file <>,   /f<>    Reads the file back to stdout. (Windows opt and GNU/POSIX arg conventions)
+                /file:<>,   /f<>    Reads the file back to stdout. (Windows conventions)
+                -file=<>,   -f<>    Reads the file back to stdout. (Powershell opt and GNU/POSIX arg conventions)
+                -file <>,   -f<>    Reads the file back to stdout. (Powershell opt and GNU/POSIX arg conventions)
+                -file:<>,   -f<>    Reads the file back to stdout. (Powershell opt and Windows arg conventions)
             """);
         }
 
         static void PrintVersion() {
-            Console.WriteLine("myapp v1.0.0");
+            Console.WriteLine("myapp v0.8.0");
         }
     }
 }

--- a/getopt.net.reference.cs/getopt.net.reference.cs.csproj
+++ b/getopt.net.reference.cs/getopt.net.reference.cs.csproj
@@ -2,10 +2,11 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
-    <ImplicitUsings>enable</ImplicitUsings>
+    <TargetFrameworks>net6.0;net7.0;net46;</TargetFrameworks>
+    <ImplicitUsings>disable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <AssemblyName>myapp</AssemblyName>
+    <LangVersion>11</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/getopt.net.reference.vb/Program.vb
+++ b/getopt.net.reference.vb/Program.vb
@@ -19,7 +19,10 @@ Module Program
         Dim getopt = New GetOpt With {
             .AppArgs = args,
             .Options = _progOptions,
-            .ShortOpts = _progShortOptions
+            .ShortOpts = _progShortOptions,
+            .AllowParamFiles = True,
+            .AllowPowershellConventions = True,
+            .AllowWindowsConventions = True
         }
 
         Dim optChar = 0
@@ -76,14 +79,30 @@ Usage:
     myapp --file=/path/to/file
     myapp --file /path/to/file
 
+    myapp @/path/to/paramfile # load all args from param file
+
 Arguments:
-    --help,         -h      Displays this text and exits
-    --version,      -v      Displays the version and exits
-    --file=[file],  -f      Reads a file and outputs its contents
+    --help,     -h      Displays this menu and exits
+    /help,      /h      Displays this menu and exits (Windows conventions)
+    -help,      -h      Displays this menu and exits (Powershell conventions)
+
+    --version,  -v      Displays the version and exits
+    /version,   /v      Displays the version and exits (Windows conventions)
+    -version,   -v      Displays the version and exits (Powershell conventions)
+
+    --file=<>,  -f<>    Reads the file back to stdout.
+    --file <>,  -f<>    Reads the file back to stdout.
+    --file:<>,  -f<>    Reads the file back to stdout. (Windows arg conventions)
+    /file=<>,   /f<>    Reads the file back to stdout. (Windows opt and GNU/POSIX arg conventions)
+    /file <>,   /f<>    Reads the file back to stdout. (Windows opt and GNU/POSIX arg conventions)
+    /file:<>,   /f<>    Reads the file back to stdout. (Windows conventions)
+    -file=<>,   -f<>    Reads the file back to stdout. (Powershell opt and GNU/POSIX arg conventions)
+    -file <>,   -f<>    Reads the file back to stdout. (Powershell opt and GNU/POSIX arg conventions)
+    -file:<>,   -f<>    Reads the file back to stdout. (Powershell opt and Windows arg conventions)
         ")
     End Sub
 
     Sub PrintVersion()
-        Console.WriteLine("myapp (VB) v1.0.0")
+        Console.WriteLine("myapp (VB) v0.8.0")
     End Sub
 End Module

--- a/getopt.net.reference.vb/getopt.net.reference.vb.vbproj
+++ b/getopt.net.reference.vb/getopt.net.reference.vb.vbproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <RootNamespace>getopt.net.reference.vb</RootNamespace>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFrameworks>net6.0;net7.0;net46;</TargetFrameworks>
     <AssemblyName>myapp</AssemblyName>
   </PropertyGroup>
 

--- a/getopt.net.sln
+++ b/getopt.net.sln
@@ -9,6 +9,7 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "getopt.net.tests", "getopt.
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{B994D393-9D31-4B65-BCCB-3FF2ACC910C3}"
 	ProjectSection(SolutionItems) = preProject
+		.editorconfig = .editorconfig
 		CHANGELOG.md = CHANGELOG.md
 		Doxyfile = Doxyfile
 		LICENSE = LICENSE
@@ -17,9 +18,9 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Reference_Implementation", "Reference_Implementation", "{C10BBB00-F878-49DA-A820-096033490427}"
 EndProject
-Project("{F184B08F-C81C-45F6-A57F-5ABD9991F28F}") = "getopt.net.reference.vb", "getopt.net.reference.vb\getopt.net.reference.vb.vbproj", "{37B43EE5-B988-486E-BED9-AA6A5835DC0D}"
+Project("{778DAE3C-4631-46EA-AA77-85C1314464D9}") = "getopt.net.reference.vb", "getopt.net.reference.vb\getopt.net.reference.vb.vbproj", "{37B43EE5-B988-486E-BED9-AA6A5835DC0D}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "getopt.net.reference.cs", "getopt.net.reference.cs\getopt.net.reference.cs.csproj", "{A367E857-0105-4824-B3B7-1334C6C21236}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "getopt.net.reference.cs", "getopt.net.reference.cs\getopt.net.reference.cs.csproj", "{A367E857-0105-4824-B3B7-1334C6C21236}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/getopt.net.tests/GetOptTests_Inherited.cs
+++ b/getopt.net.tests/GetOptTests_Inherited.cs
@@ -217,6 +217,7 @@
             ReadParamFile(new FileInfo(tmpFile));
             Assert.AreEqual(4, AppArgs.Length);
 
+            // NOTE: GetNextOpt calls ReadParamFile too! AppArgs will now contain double the amount of args written to the file :)
             char optChar = (char)GetNextOpt(out var optArg);
             Assert.AreEqual('t', optChar);
             Assert.IsNull(optArg);

--- a/getopt.net.tests/GetOptTests_Inherited.cs
+++ b/getopt.net.tests/GetOptTests_Inherited.cs
@@ -179,6 +179,69 @@
             Assert.IsNull(ShortOptRequiresArg('z'));
         }
 
+        [TestMethod]
+        public void TestIsParamFileArg() {
+            var tmpFile = Path.GetTempFileName();
+            AllowParamFiles = true;
+            Assert.IsTrue(IsParamFileArg($"@{tmpFile}", out var paramFile));
+            Assert.IsNotNull(paramFile);
+            Assert.IsFalse(string.IsNullOrEmpty(paramFile));
+            Assert.AreEqual(tmpFile, paramFile);
+
+            Assert.IsFalse(IsParamFileArg("--long-opt", out paramFile));
+            Assert.IsNull(paramFile);
+
+            AllowParamFiles = false;
+            Assert.IsFalse(IsParamFileArg($"@{tmpFile}", out paramFile));
+            Assert.IsNull(paramFile);
+        }
+
+        [TestMethod]
+        public void TestParseParamFile() {
+            var tmpFile = Path.GetTempFileName();
+            File.WriteAllLines(tmpFile, new[] {
+                "-1234", "--long"
+            });
+            AllowParamFiles = true;
+            AppArgs = new[] { $"@{ tmpFile }", "--test" };
+            ShortOpts = string.Empty;
+            Options = new[] {
+                new Option("first", ArgumentType.None, '1'),
+                new Option("second", ArgumentType.None, '2'),
+                new Option("third", ArgumentType.None, '3'),
+                new Option("fourth", ArgumentType.None, '4'),
+                new Option("long", ArgumentType.None, '5'),
+                new Option("test", ArgumentType.None, 't')
+            };
+
+            ReadParamFile(new FileInfo(tmpFile));
+            Assert.AreEqual(4, AppArgs.Length);
+
+            char optChar = (char)GetNextOpt(out var optArg);
+            Assert.AreEqual('t', optChar);
+            Assert.IsNull(optArg);
+
+            optChar = (char)GetNextOpt(out optArg);
+            Assert.AreEqual('1', optChar);
+            Assert.IsNull(optArg);
+
+            optChar = (char)GetNextOpt(out optArg);
+            Assert.AreEqual('2', optChar);
+            Assert.IsNull(optArg);
+
+            optChar = (char)GetNextOpt(out optArg);
+            Assert.AreEqual('3', optChar);
+            Assert.IsNull(optArg);
+
+            optChar = (char)GetNextOpt(out optArg);
+            Assert.AreEqual('4', optChar);
+            Assert.IsNull(optArg);
+
+            optChar = (char)GetNextOpt(out optArg);
+            Assert.AreEqual('5', optChar);
+            Assert.IsNull(optArg);
+        }
+
     }
 
 }

--- a/getopt.net.tests/GetOptTests_RealWorld.cs
+++ b/getopt.net.tests/GetOptTests_RealWorld.cs
@@ -495,5 +495,91 @@ namespace getopt.net.tests {
             Assert.IsNull(optArg);
         }
 
+        [TestMethod]
+        public void TestPowershellConvention_LongOptions() {
+            var getopt = new GetOpt {
+                Options = new[] {
+                    new Option("test", ArgumentType.None, '1'),
+                    new Option("test2", ArgumentType.Optional, '2'),
+                    new Option("test3", ArgumentType.Required, '3')
+                },
+                AllowPowershellConventions = true,
+                AppArgs = new[] { "-test", "-1", "-test2", "-2", "-test2:arg", "-test2=arg", "-test2 arg", "-test2", "arg", "-test3:arg", "-test3=arg", "-test3 arg", "-test3", "arg", "-12", "-3", "arg" }
+            };
+
+            const string testArg = "arg";
+
+            var optChar = (char)getopt.GetNextOpt(out var optArg);
+            Assert.AreEqual('1', optChar);
+            Assert.IsNull(optArg);
+
+            optChar = (char)getopt.GetNextOpt(out optArg);
+            Assert.AreEqual('1', optChar);
+            Assert.IsNull(optArg);
+
+            optChar = (char)getopt.GetNextOpt(out optArg);
+            Assert.AreEqual('2', optChar);
+            Assert.IsNull(optArg);
+
+            optChar = (char)getopt.GetNextOpt(out optArg);
+            Assert.AreEqual('2', optChar);
+            Assert.IsNull(optArg);
+
+            getopt.AllowWindowsConventions = true;
+            optChar = (char)getopt.GetNextOpt(out optArg);
+            Assert.AreEqual('2', optChar);
+            Assert.IsNotNull(optArg);
+            Assert.AreEqual(testArg, optArg);
+
+
+            optChar = (char)getopt.GetNextOpt(out optArg);
+            Assert.AreEqual('2', optChar);
+            Assert.IsNotNull(optArg);
+            Assert.AreEqual(testArg, optArg);
+
+            optChar = (char)getopt.GetNextOpt(out optArg);
+            Assert.AreEqual('2', optChar);
+            Assert.IsNotNull(optArg);
+            Assert.AreEqual(testArg, optArg);
+
+            optChar = (char)getopt.GetNextOpt(out optArg);
+            Assert.AreEqual('2', optChar);
+            Assert.IsNotNull(optArg);
+            Assert.AreEqual(testArg, optArg);
+
+            optChar = (char)getopt.GetNextOpt(out optArg);
+            Assert.AreEqual('3', optChar);
+            Assert.IsNotNull(optArg);
+            Assert.AreEqual(testArg, optArg);
+
+            optChar = (char)getopt.GetNextOpt(out optArg);
+            Assert.AreEqual('3', optChar);
+            Assert.IsNotNull(optArg);
+            Assert.AreEqual(testArg, optArg);
+
+            optChar = (char)getopt.GetNextOpt(out optArg);
+            Assert.AreEqual('3', optChar);
+            Assert.IsNotNull(optArg);
+            Assert.AreEqual(testArg, optArg);
+
+            optChar = (char)getopt.GetNextOpt(out optArg);
+            Assert.AreEqual('3', optChar);
+            Assert.IsNotNull(optArg);
+            Assert.AreEqual(testArg, optArg);
+
+            optChar = (char)getopt.GetNextOpt(out optArg);
+            Assert.AreEqual('1', optChar);
+            Assert.IsNull(optArg);
+
+            optChar = (char)getopt.GetNextOpt(out optArg);
+            Assert.AreEqual('2', optChar);
+            Assert.IsNull(optArg);
+
+            optChar = (char)getopt.GetNextOpt(out optArg);
+            Assert.AreEqual('3', optChar);
+            Assert.IsNotNull(optArg);
+            Assert.AreEqual(testArg, optArg);
+        }
+
     }
 }

--- a/getopt.net/GetOpt.cs
+++ b/getopt.net/GetOpt.cs
@@ -303,6 +303,7 @@ namespace getopt.net {
             // Now check if the current argument is a paramfile argument
             if (IsParamFileArg(AppArgs[CurrentIndex], out var paramFile)) {
                 ReadParamFile(new FileInfo(paramFile));
+                m_currentIndex++;
                 return GetNextOpt(out outOptArg); // We don't need to pass this back to the application. Instead just continue on
             }
 
@@ -688,7 +689,7 @@ namespace getopt.net {
         protected void ReadParamFile(FileInfo paramFile) {
             if (paramFile == null || !paramFile.Exists) { return; }
 
-            var lastIndex = AppArgs.Length - 1;
+            var lastIndex = AppArgs.Length;
             var lines = File.ReadAllLines(paramFile.FullName);
             Array.Resize(ref m_appArgs, lines.Length + AppArgs.Length);
 

--- a/getopt.net/GetOpt.cs
+++ b/getopt.net/GetOpt.cs
@@ -177,17 +177,6 @@ namespace getopt.net {
         /// </remarks>
         public bool AllowParamFiles { get; set; } = false;
 
-        /// <summary>
-        /// Gets or sets a value indicating whether or not Powershell-style arguments are allowed.
-        /// This option doesn't conflict with the GNU/POSIX or Windows-style argument parsing and is simply an addition.
-        /// </summary>
-        /// <remarks >
-        /// This option is disabled by default.
-        /// 
-        /// Powershell-style arguments are similar to GNU/POSIX long options, however they begin with a single dash (-).
-        /// </remarks>
-        public bool AllowPowershellConventions { get; set; } = false;
-
 
         /// <summary>
         /// Either enables or disabled exceptions entirely.

--- a/getopt.net/GetOpt.cs
+++ b/getopt.net/GetOpt.cs
@@ -301,7 +301,7 @@ namespace getopt.net {
             }
 
             // Now check if the current argument is a paramfile argument
-            if (IsParamFileArg(AppArgs[CurrentIndex], out var paramFile)) {
+            if (IsParamFileArg(AppArgs[CurrentIndex], out var paramFile) && paramFile is not null) {
                 ReadParamFile(new FileInfo(paramFile));
                 m_currentIndex++;
                 return GetNextOpt(out outOptArg); // We don't need to pass this back to the application. Instead just continue on
@@ -686,6 +686,10 @@ namespace getopt.net {
             return true;
         }
 
+        /// <summary>
+        /// Reads the incoming param file and adds the contents to <see cref="AppArgs"/>
+        /// </summary>
+        /// <param name="paramFile">The file to read.</param>
         protected void ReadParamFile(FileInfo paramFile) {
             if (paramFile == null || !paramFile.Exists) { return; }
 

--- a/getopt.net/GetOpt.cs
+++ b/getopt.net/GetOpt.cs
@@ -137,6 +137,18 @@ namespace getopt.net {
         public bool AllowWindowsConventions { get; set; } = false;
 
         /// <summary>
+        /// Gets or sets a value indicating whether or not Powershell-style arguments are allowed.
+        /// This option doesn't conflict with the GNU/POSIX or Windows-style argument parsing and is simply an addition.
+        /// </summary>
+        /// <remarks >
+        /// This option is disabled by default.
+        /// 
+        /// Powershell-style arguments are similar to GNU/POSIX long options, however they begin with a single dash (-).
+        /// </remarks>
+        public bool AllowPowershellConventions { get; set; } = false;
+
+
+        /// <summary>
         /// Either enables or disabled exceptions entirely.
         /// For more specific control over exceptions, see the other options provided by GetOpt.
         /// </summary>
@@ -572,6 +584,19 @@ namespace getopt.net {
                 arg[0] == SingleSlash   &&
                 Options.Length != 0     &&
                 Options.Any(o => o.Name == arg.Split(WinArgSeparator, GnuArgSeparator, ' ').First().Substring(1)) // We only need this option when parsing options following Windows' conventions
+            ) { return true; }
+
+            // Check for Powershell-style arguments.
+            // Powershell arguments are weird and extra checks are needed.
+            // Powershell-style arguments would theoretically interfere with short opts,
+            // so a check to determine whether or not the option is found in Options is required.
+            if (
+                AllowPowershellConventions  &&
+                arg.Length > 1              &&
+                arg[0] == SingleDash        &&
+                Options.Length != 0         &&
+                Options.Any(o => o.Name == arg.Split(WinArgSeparator, GnuArgSeparator, ' ').First().Substring(1)) // We only need this when parsing options following Powershell's conventions
+                // This parsing method is really similar to Windows option parsing...
             ) { return true; }
 
             return arg.Length > 2       &&

--- a/getopt.net/GetOpt.cs
+++ b/getopt.net/GetOpt.cs
@@ -147,6 +147,24 @@ namespace getopt.net {
         /// </remarks>
         public bool AllowPowershellConventions { get; set; } = false;
 
+        /// <summary>
+        /// Gets or sets a value indicating whether or not parameter files are accepted as a valid form of input.
+        /// 
+        /// Parameter files are known from some software, such as GCC.
+        /// A param file can be passed as <code>@/path/to/file</code>.
+        /// </summary>
+        /// <remarks >
+        /// Param files must follow certain rules, in order to be accepted by getopt.net.
+        /// 
+        ///  - Param files MUST be text files, the file ending doesn't matter.
+        ///  - The contents of the file MUST be split by \n (newlines).
+        ///  - OR the file must contain a valid JSON array
+        ///  - each line or JSON entry must be an argument acceptable by getopt.net, depending on the options set.
+        ///    - i.e. to accept Windows-convention arguments, <see cref="AllowWindowsConventions"/> must be enabled
+        ///    - to accept Powershell-convention arguments, <see cref="AllowPowershellConventions"/> must be enabled
+        ///  - paramfile arguments (`@/path/to/file`) may be added in addition to any other arguments!
+        /// </remarks>
+        public bool AllowParamFiles { get; set; } = false;
 
         /// <summary>
         /// Either enables or disabled exceptions entirely.

--- a/getopt.net/getopt.net.csproj
+++ b/getopt.net/getopt.net.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net46;net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net7.0;net46;</TargetFrameworks>
     <ImplicitUsings>disable</ImplicitUsings>
     <LangVersion>11</LangVersion>
     <Nullable>enable</Nullable>
@@ -35,7 +35,7 @@ Changes
     </PackageReleaseNotes>
     <Title>getopt.net</Title>
     <PackageRequireLicenseAcceptance>True</PackageRequireLicenseAcceptance>
-    <PackageIcon >getopt.net-logo-128.png</PackageIcon>
+    <PackageIcon>getopt.net-logo-128.png</PackageIcon>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
@@ -49,6 +49,7 @@ Changes
     <SignAssembly>true</SignAssembly>
   </PropertyGroup>
   <ItemGroup>
+    <None Include="..\.editorconfig" Link=".editorconfig" />
     <None Include="..\LICENSE">
       <Pack>True</Pack>
       <PackagePath>\</PackagePath>
@@ -57,9 +58,9 @@ Changes
       <Pack>True</Pack>
       <PackagePath>\</PackagePath>
     </None>
-    <None Include="..\img\getopt.net-logo-128.png" >
+    <None Include="..\img\getopt.net-logo-128.png">
         <Pack>True</Pack>
-        <PackagePath >\</PackagePath>
+        <PackagePath>\</PackagePath>
     </None>
   </ItemGroup>
 

--- a/getopt.net/getopt.net.csproj
+++ b/getopt.net/getopt.net.csproj
@@ -22,16 +22,16 @@ GitHub: https://github.com/SimonCahill/getopt.net</Description>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
     <!--<ApplicationIcon >../img/getopt.net-icon.ico</ApplicationIcon>-->
-    <Version>0.6.0</Version>
+    <Version>0.7.0</Version>
     <PackageTags>getopt; getopt.net; argument-parsing; parser; arguments; options; getopt_long</PackageTags>
     <PackageReleaseNotes>
-v0.6.0
+v0.7.0
 
-Version 0.6.0 introduces a non-breaking change which enabled support for optional short-opt arguments!
+Version 0.7.0 introduces a non-breaking change which enables support for Powershell-style options!
 Check out the wiki/README for more info!
 
 Changes
-  - Added support for optional short args!
+  - Added support for Powershell-style arguments.
     </PackageReleaseNotes>
     <Title>getopt.net</Title>
     <PackageRequireLicenseAcceptance>True</PackageRequireLicenseAcceptance>

--- a/getopt.net/getopt.net.csproj
+++ b/getopt.net/getopt.net.csproj
@@ -22,16 +22,22 @@ GitHub: https://github.com/SimonCahill/getopt.net</Description>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
     <!--<ApplicationIcon >../img/getopt.net-icon.ico</ApplicationIcon>-->
-    <Version>0.7.0</Version>
-    <PackageTags>getopt; getopt.net; argument-parsing; parser; arguments; options; getopt_long</PackageTags>
+    <Version>0.8.0</Version>
+    <PackageTags>getopt; getopt.net; argument-parsing; parser; arguments; options; getopt_long; options; command-line; cross-platform; linux; macos; windows</PackageTags>
     <PackageReleaseNotes>
-v0.7.0
+# v0.8.0
 
-Version 0.7.0 introduces a non-breaking change which enables support for Powershell-style options!
-Check out the wiki/README for more info!
+Version 0.8.0 introduces a non-breaking change which enables support for paramfiles!
 
-Changes
-  - Added support for Powershell-style arguments.
+Some applications, notably GCC, use paramfiles as a way to pass a large amount of options and arguments to an application.
+Paramfiles are line-separated lists of arguments and can be enabled by setting `AllowParamFiles = true`.
+Each line in the paramfile will be parsed as if it were passed directly to getopt.net!
+To allow Powershell or Windows conventions, you will still need to enable `AllowWindowsConventions` or `AllowPowershellConventions` respectively.
+
+## Changes
+ - Added support for paramfiles
+ - Updated reference implementations
+
     </PackageReleaseNotes>
     <Title>getopt.net</Title>
     <PackageRequireLicenseAcceptance>True</PackageRequireLicenseAcceptance>


### PR DESCRIPTION
Some applications, notably GCC, use param files to make passing options and arguments to an application easier/better automatable.

This feature enables parsing of such paramfiles.

See the changelog and README for more information.