### PR TITLE
Feat longer opt values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # getop.net changelog
 
+# v0.8.1
+Version 0.8.1 introduces a non-breaking change which allows for more than 255 possible values for long options.
+
+## Changes
+ - Option struct now contains an Int32 for its Value property
+    - An override constructor was added to allow for backwards-compatiblity.
+
 # v0.8.0
 
 Version 0.8.0 introduces a non-breaking change which enables support for paramfiles!

--- a/getopt.net.tests/GetOptTests_RealWorld.cs
+++ b/getopt.net.tests/GetOptTests_RealWorld.cs
@@ -581,5 +581,24 @@ namespace getopt.net.tests {
             Assert.AreEqual(testArg, optArg);
         }
 
+        [TestMethod]
+        public void TestOptionsWithLongerIntValues() {
+            var getopt = new GetOpt {
+                AppArgs = new[] { "--long-one", "--long-two" },
+                Options = new[] {
+                    new Option("long-one", ArgumentType.None, 0xbada55),
+                    new Option("long-two", ArgumentType.None, 0xdeada55)
+                }
+            };
+
+            var optChar = getopt.GetNextOpt(out var optArg);
+            Assert.AreEqual(0xbada55, optChar);
+            Assert.IsNull(optArg);
+
+            optChar = getopt.GetNextOpt(out optArg);
+            Assert.AreEqual(0xdeada55, optChar);
+            Assert.IsNull(optArg);
+        }
+
     }
 }

--- a/getopt.net/Option.cs
+++ b/getopt.net/Option.cs
@@ -13,12 +13,20 @@ namespace getopt.net {
         public Option() { }
 
         /// <summary>
-        /// Constructs a new instance of this struct.
+        /// Constructs a new instance of this struct with a <see cref="char"/> as the value type.
         /// </summary>
         /// <param name="name">The name of the argument.</param>
         /// <param name="argType">The argument type.</param>
         /// <param name="value">The value of the option.</param>
-        public Option(string name, ArgumentType argType, char value) {
+        public Option(string name, ArgumentType argType, char value): this(name, argType, (int)value) { }
+
+        /// <summary>
+        /// Constructs a new instance of this struct with an <see cref="int"/> as the value type.
+        /// </summary>
+        /// <param name="name"></param>
+        /// <param name="argType"></param>
+        /// <param name="value"></param>
+        public Option(string name, ArgumentType argType, int value) {
             Name = name;
             ArgumentType = argType;
             Value = value;

--- a/getopt.net/Option.cs
+++ b/getopt.net/Option.cs
@@ -2,49 +2,49 @@
 
 namespace getopt.net {
 
-	/// <summary>
-	/// Represents a single long option for getopt.
-	/// </summary>
-	public struct Option {
+    /// <summary>
+    /// Represents a single long option for getopt.
+    /// </summary>
+    public struct Option {
 
-		/// <summary>
-		/// Constructs a new, empty instance of this struct.
-		/// </summary>
-		public Option() { }
+        /// <summary>
+        /// Constructs a new, empty instance of this struct.
+        /// </summary>
+        public Option() { }
 
-		/// <summary>
-		/// Constructs a new instance of this struct.
-		/// </summary>
-		/// <param name="name">The name of the argument.</param>
-		/// <param name="argType">The argument type.</param>
-		/// <param name="value">The value of the option.</param>
-		public Option(string name, ArgumentType argType, char value) {
-			Name = name;
-			ArgumentType = argType;
-			Value = value;
-		}
+        /// <summary>
+        /// Constructs a new instance of this struct.
+        /// </summary>
+        /// <param name="name">The name of the argument.</param>
+        /// <param name="argType">The argument type.</param>
+        /// <param name="value">The value of the option.</param>
+        public Option(string name, ArgumentType argType, char value) {
+            Name = name;
+            ArgumentType = argType;
+            Value = value;
+        }
 
-		/// <summary>
-		/// The name of the (long) option
-		/// </summary>
-		/// <remarks >
-		/// Do not prefix this with dashes.
-		/// </remarks>
-		/// <example >
-		/// help
-		/// </example>
-		public string? Name { get; set; }
+        /// <summary>
+        /// The name of the (long) option
+        /// </summary>
+        /// <remarks >
+        /// Do not prefix this with dashes.
+        /// </remarks>
+        /// <example >
+        /// help
+        /// </example>
+        public string? Name { get; set; }
 
-		/// <summary>
-		/// The type of argument this option requires.
-		/// </summary>
-		public ArgumentType? ArgumentType { get; set; }
+        /// <summary>
+        /// The type of argument this option requires.
+        /// </summary>
+        public ArgumentType? ArgumentType { get; set; }
 
-		/// <summary>
-		/// The value (short opt) for the option.
-		/// </summary>
-		public char Value { get; set; }
+        /// <summary>
+        /// The value (short opt) for the option.
+        /// </summary>
+        public int Value { get; set; }
 
-	}
+    }
 }
 

--- a/getopt.net/getopt.net.csproj
+++ b/getopt.net/getopt.net.csproj
@@ -22,21 +22,15 @@ GitHub: https://github.com/SimonCahill/getopt.net</Description>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
     <!--<ApplicationIcon >../img/getopt.net-icon.ico</ApplicationIcon>-->
-    <Version>0.8.0</Version>
+    <Version>0.8.1</Version>
     <PackageTags>getopt; getopt.net; argument-parsing; parser; arguments; options; getopt_long; options; command-line; cross-platform; linux; macos; windows</PackageTags>
     <PackageReleaseNotes>
-# v0.8.0
+v0.8.1
+Version 0.8.1 introduces a non-breaking change which allows for more than 255 possible values for long options.
 
-Version 0.8.0 introduces a non-breaking change which enables support for paramfiles!
-
-Some applications, notably GCC, use paramfiles as a way to pass a large amount of options and arguments to an application.
-Paramfiles are line-separated lists of arguments and can be enabled by setting `AllowParamFiles = true`.
-Each line in the paramfile will be parsed as if it were passed directly to getopt.net!
-To allow Powershell or Windows conventions, you will still need to enable `AllowWindowsConventions` or `AllowPowershellConventions` respectively.
-
-## Changes
- - Added support for paramfiles
- - Updated reference implementations
+Changes
+ - Option struct now contains an Int32 for its Value property
+    - An override constructor was added to allow for backwards-compatiblity.
     </PackageReleaseNotes>
     <Title>getopt.net</Title>
     <PackageRequireLicenseAcceptance>True</PackageRequireLicenseAcceptance>


### PR DESCRIPTION
This PR merges a non-breaking change to getopt.net, allowing for more than 255 possible values for a long option.