### PR TITLE
Add help text generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # getop.net changelog
 
+# v1.0.0
+Version 1.0.0 introduces a non-breaking feature; the dynamic creation of help menus.
+
+## Changes
+ - getopt.net now generates a dynamic help text.
+    - Added customisable extension method which can be used to dynamically generate help texts.
+
 # v0.9.1
 Version 0.9.1 introduces a non-breaking change which allows creating a shortopt string from an array of long options.
 

--- a/README.md
+++ b/README.md
@@ -135,6 +135,69 @@ If `IgnoreMissingArguments` is enabled, forgetting to add a **required** argumen
 
 The exceptions *do* contain more info, however.
 
+### Help text generation
+getopt.net can generate a help text for you, by simply calling `getopt.GenerateHelpText()`.
+
+The behaviour of the help text generator can be customised to suit your needs.
+By default, getopt.net will not output application name, version or copyright information. This must be provided with the `HelpTextConfig` object.
+
+If no application name is provided, getopt.net will attempt to read the application name from the Assembly.  
+Should this fail, getopt.net will identify your program as `unknown`.
+
+The default configuration outputs options and switches using the GNU/POSIX convention and **doesn't** print the conventions supported by your application.
+
+Here's an example:
+
+```cs
+var getopt = new GetOpt {
+    AppArgs = args,
+    Options = new[] {
+        new Option("help",      ArgumentType.None,      'h', "Displays this help text."),
+        new Option("version",   ArgumentType.None,      'v', "Displays the version of this program."),
+        new Option("file",      ArgumentType.Required,  'f', "Reads the file back to stdout. The file is read into a local buffer and then printed out. Also I created this really long description to show that getopt.net can handle long descriptions."),
+    },
+    ShortOpts = "hvf:t;", // the last option isn't an error!
+    AllowParamFiles = true,
+    AllowWindowsConventions = true,
+    AllowPowershellConventions = true
+};
+
+static void PrintHelp(GetOpt getopt) {
+    Console.WriteLine(getopt.GenerateHelpText(new HelpTextConfig {
+        ApplicationName = "getopt.net reference",
+        ApplicationVersion = "v1.0.0",
+        FooterText = "This is a reference implementation of getopt.net in C#.",
+        OptionConvention = OptionConvention.GnuPosix, // Change me to different conventions
+        ShowSupportedConventions = true // I'm false by default, but enabling me shows which conventions your app supports
+    }));
+}
+```
+
+produces the following output:
+
+```
+getopt.net reference v1.0.0
+
+Usage:
+        getopt.net reference [options]
+
+Supported option conventions:
+    Windows (/): yes
+    Powershell (-): yes
+    Gnu/Posix (-, --): yes
+
+Switches:
+        -h, --help      Displays this help text.
+        -v, --version   Displays the version of this program.
+
+Options:
+                        Reads the file back to stdout. The file is read into a local buffer and then printed out. Also I created this really long description to show
+        -f, --file      that getopt.net can handle long descriptions.
+
+
+This is a reference implementation of getopt.net in C#.
+```
+
 # Usage:
 
 For a more detailled description of using getopt.net, please consult the Wiki.
@@ -168,7 +231,9 @@ static void Main(string[] args) {
             case 'h':
                 // print help or something
                 break;
-            //
+            case 'c':
+                // do something with optArg
+                break;
         }
     }
 }
@@ -176,7 +241,7 @@ static void Main(string[] args) {
 
 ## Basic usage in VB.Net
 
-```vbnet
+```vb
 Imports getopt.net
 
 module Program

--- a/getopt.net.reference.cs/Program.cs
+++ b/getopt.net.reference.cs/Program.cs
@@ -61,7 +61,9 @@ namespace getopt.net.reference.cs {
                 ApplicationVersion = "v1.0.0",
                 FooterText = "This is a reference implementation of getopt.net in C#.",
                 OptionConvention = OptionConvention.GnuPosix,
-                ShowSupportedConventions = true
+                ShowSupportedConventions = true,
+                CopyrightDate = new DateTime(2023, 1, 1),
+                CopyrightHolder = "Simon Cahill (contact@simonc.eu)"
             }));
         }
 

--- a/getopt.net.reference.cs/Program.cs
+++ b/getopt.net.reference.cs/Program.cs
@@ -10,9 +10,9 @@ namespace getopt.net.reference.cs {
             var getopt = new GetOpt {
                 AppArgs = args,
                 Options = new[] {
-                    new Option("help",      ArgumentType.None,      'h'),
-                    new Option("version",   ArgumentType.None,      'v'),
-                    new Option("file",      ArgumentType.Required,  'f')
+                    new Option("help",      ArgumentType.None,      'h', "Displays this help text."),
+                    new Option("version",   ArgumentType.None,      'v', "Displays the version of this program."),
+                    new Option("file",      ArgumentType.Required,  'f', "Reads the file back to stdout. The file is read into a local buffer and then printed out. Also I created this really long description to show that getopt.net can handle long descriptions."),
                 },
                 ShortOpts = "hvf:t;", // the last option isn't an error!
                 AllowParamFiles = true,
@@ -26,7 +26,7 @@ namespace getopt.net.reference.cs {
             while ((optChar = getopt.GetNextOpt(out var optArg)) != -1) {
                 switch (optChar) {
                     case 'h':
-                        PrintHelp();
+                        PrintHelp(getopt);
                         return 0;
                     case 'v':
                         PrintVersion();
@@ -55,40 +55,14 @@ namespace getopt.net.reference.cs {
             return 0;
         }
 
-        static void PrintHelp() {
-            Console.WriteLine(
-            """
-            myapp (C#) v1.0.0
-            This app displays the usage of getopt.net in C#.
-
-            Usage:
-                myapp [-h/--help] [-v/--version]
-                myapp -f/path/to/file
-                myapp -f /path/to/file
-                myapp --file=/path/to/file
-                myapp --file /path/to/file
-
-                myapp @/path/to/paramfile # load all args from param file
-            
-            Arguments:
-                --help,     -h      Displays this menu and exits
-                /help,      /h      Displays this menu and exits (Windows conventions)
-                -help,      -h      Displays this menu and exits (Powershell conventions)
-
-                --version,  -v      Displays the version and exits
-                /version,   /v      Displays the version and exits (Windows conventions)
-                -version,   -v      Displays the version and exits (Powershell conventions)
-
-                --file=<>,  -f<>    Reads the file back to stdout.
-                --file <>,  -f<>    Reads the file back to stdout.
-                --file:<>,  -f<>    Reads the file back to stdout. (Windows arg conventions)
-                /file=<>,   /f<>    Reads the file back to stdout. (Windows opt and GNU/POSIX arg conventions)
-                /file <>,   /f<>    Reads the file back to stdout. (Windows opt and GNU/POSIX arg conventions)
-                /file:<>,   /f<>    Reads the file back to stdout. (Windows conventions)
-                -file=<>,   -f<>    Reads the file back to stdout. (Powershell opt and GNU/POSIX arg conventions)
-                -file <>,   -f<>    Reads the file back to stdout. (Powershell opt and GNU/POSIX arg conventions)
-                -file:<>,   -f<>    Reads the file back to stdout. (Powershell opt and Windows arg conventions)
-            """);
+        static void PrintHelp(GetOpt getopt) {
+            Console.WriteLine(getopt.GenerateHelpText(new HelpTextConfig {
+                ApplicationName = "getopt.net reference",
+                ApplicationVersion = "v1.0.0",
+                FooterText = "This is a reference implementation of getopt.net in C#.",
+                OptionConvention = OptionConvention.GnuPosix,
+                ShowSupportedConventions = true
+            }));
         }
 
         static void PrintVersion() {

--- a/getopt.net.tests/GetOptTests_Other.cs
+++ b/getopt.net.tests/GetOptTests_Other.cs
@@ -63,6 +63,21 @@ namespace getopt.net.tests {
             Assert.IsFalse(getopt.IgnoreInvalidOptions);
         }
 
+        public void TestHelpGeneration() {
+            var getopt = new GetOpt {
+                Options = new Option[] {
+                    new Option("help", ArgumentType.None, 'h', "Displays this help text."),
+                    new Option("version", ArgumentType.None, 'v', "Displays the version of this program.")
+                }
+            };
+
+            var helpText = getopt.GenerateHelpText();
+            Console.WriteLine(helpText);
+            Assert.IsNotNull(helpText);
+            Assert.IsTrue(helpText.Contains("help"));
+            Assert.IsTrue(helpText.Contains("version"));
+        }
+
     }
 
 }

--- a/getopt.net.tests/GetOptTests_Other.cs
+++ b/getopt.net.tests/GetOptTests_Other.cs
@@ -63,6 +63,7 @@ namespace getopt.net.tests {
             Assert.IsFalse(getopt.IgnoreInvalidOptions);
         }
 
+        [TestMethod]
         public void TestHelpGeneration() {
             var getopt = new GetOpt {
                 Options = new Option[] {
@@ -72,10 +73,128 @@ namespace getopt.net.tests {
             };
 
             var helpText = getopt.GenerateHelpText();
-            Console.WriteLine(helpText);
             Assert.IsNotNull(helpText);
             Assert.IsTrue(helpText.Contains("help"));
             Assert.IsTrue(helpText.Contains("version"));
+        }
+
+        [TestMethod]
+        public void TestHelpGeneration_WithConfig() {
+            var getopt = new GetOpt {
+                Options = new Option[] {
+                    new Option("help", ArgumentType.None, 'h', "Displays this help text."),
+                    new Option("version", ArgumentType.None, 'v', "Displays the version of this program.")
+                }
+            };
+
+            var helpText = getopt.GenerateHelpText(new HelpTextConfig {
+                ApplicationName = "getopt.net reference",
+                ApplicationVersion = "1.0.0",
+                FooterText = "This is a footer text."
+            });
+
+            Assert.IsNotNull(helpText);
+            Assert.IsTrue(helpText.Contains("help"));
+            Assert.IsTrue(helpText.Contains("version"));
+            Assert.IsTrue(helpText.Contains("getopt.net reference"));
+            Assert.IsTrue(helpText.Contains("1.0.0"));
+            Assert.IsTrue(helpText.Contains("This is a footer text."));
+        }
+
+        [TestMethod]
+        public void TestHelpGeneration_WithCopyright() {
+            var getopt = new GetOpt {
+                Options = new Option[] {
+                    new Option("help", ArgumentType.None, 'h', "Displays this help text."),
+                    new Option("version", ArgumentType.None, 'v', "Displays the version of this program.")
+                }
+            };
+
+            var helpText = getopt.GenerateHelpText(new HelpTextConfig {
+                ApplicationName = "getopt.net reference",
+                ApplicationVersion = "1.0.0",
+                FooterText = "This is a footer text.",
+                CopyrightDate = new DateTime(2021, 1, 1),
+                CopyrightHolder = "Simon Cahill"
+            });
+
+            Assert.IsNotNull(helpText);
+            Assert.IsTrue(helpText.Contains("help"));
+            Assert.IsTrue(helpText.Contains("version"));
+            Assert.IsTrue(helpText.Contains("getopt.net reference"));
+            Assert.IsTrue(helpText.Contains("1.0.0"));
+            Assert.IsTrue(helpText.Contains("This is a footer text."));
+            Assert.IsTrue(helpText.Contains("©"));
+            Assert.IsTrue(helpText.Contains("2021"));
+            Assert.IsTrue(helpText.Contains("Simon Cahill"));
+        }
+
+        [TestMethod]
+        public void TestHelpGeneration_WithConfig_WithCopyright_WithWindowsConvention() {
+            var getopt = new GetOpt {
+                Options = new Option[] {
+                    new Option("help", ArgumentType.None, 'h', "Displays this help text."),
+                    new Option("version", ArgumentType.None, 'v', "Displays the version of this program.")
+                }
+            };
+
+            var helpText = getopt.GenerateHelpText(new HelpTextConfig {
+                ApplicationName = "getopt.net reference",
+                ApplicationVersion = "1.0.0",
+                FooterText = "This is a footer text.",
+                OptionConvention = OptionConvention.Windows,
+                ShowSupportedConventions = true,
+                CopyrightDate = new DateTime(2021, 1, 1),
+                CopyrightHolder = "Simon Cahill"
+            });
+
+            Assert.IsNotNull(helpText);
+            Assert.IsTrue(helpText.Contains("/help"));
+            Assert.IsTrue(helpText.Contains("/version"));
+            Assert.IsTrue(helpText.Contains("/h"));
+            Assert.IsTrue(helpText.Contains("/v"));
+            Assert.IsTrue(helpText.Contains("/h, /help"));
+            Assert.IsTrue(helpText.Contains("/v, /version"));
+            Assert.IsTrue(helpText.Contains("getopt.net reference"));
+            Assert.IsTrue(helpText.Contains("1.0.0"));
+            Assert.IsTrue(helpText.Contains("This is a footer text."));
+            Assert.IsTrue(helpText.Contains("©"));
+            Assert.IsTrue(helpText.Contains("2021"));
+            Assert.IsTrue(helpText.Contains("Simon Cahill"));
+        }
+
+        [TestMethod]
+        public void TestHelpGeneration_WithConfig_WithCopyright_WithPowershellConvention() {
+            var getopt = new GetOpt {
+                Options = new Option[] {
+                    new Option("help", ArgumentType.None, 'h', "Displays this help text."),
+                    new Option("version", ArgumentType.None, 'v', "Displays the version of this program.")
+                }
+            };
+
+            var helpText = getopt.GenerateHelpText(new HelpTextConfig {
+                ApplicationName = "getopt.net reference",
+                ApplicationVersion = "1.0.0",
+                FooterText = "This is a footer text.",
+                OptionConvention = OptionConvention.Powershell,
+                ShowSupportedConventions = true,
+                CopyrightDate = new DateTime(2021, 1, 1),
+                CopyrightHolder = "Simon Cahill"
+            });
+
+            Assert.IsNotNull(helpText);
+            Assert.IsTrue(helpText.Contains("-help"));
+            Assert.IsTrue(helpText.Contains("-version"));
+            Assert.IsTrue(helpText.Contains("-h"));
+            Assert.IsTrue(helpText.Contains("-v"));
+            Assert.IsTrue(helpText.Contains("-h, -help"));
+            Assert.IsTrue(helpText.Contains("-v, -version"));
+            Assert.IsTrue(helpText.Contains("getopt.net reference"));
+            Assert.IsTrue(helpText.Contains("1.0.0"));
+            Assert.IsTrue(helpText.Contains("This is a footer text."));
+            Assert.IsTrue(helpText.Contains("©"));
+            Assert.IsTrue(helpText.Contains("2021"));
+            Assert.IsTrue(helpText.Contains("Simon Cahill"));
         }
 
     }

--- a/getopt.net/Extensions.cs
+++ b/getopt.net/Extensions.cs
@@ -105,8 +105,12 @@ namespace getopt.net {
             var sBuilder = new StringBuilder();
 
             if (!string.IsNullOrEmpty(config.ApplicationName) && !string.IsNullOrEmpty(config.ApplicationVersion)) {
-                sBuilder.AppendLine($"{config.ApplicationName} {config.ApplicationVersion}");
-                sBuilder.AppendLine();
+                sBuilder.Append($"{config.ApplicationName} {config.ApplicationVersion}");
+                if (config.CopyrightDate is not null && !string.IsNullOrEmpty(config.CopyrightHolder)) {
+                    sBuilder.Append($" © {config.CopyrightDate.Value.Year} {config.CopyrightHolder}");
+                }
+                sBuilder.AppendLine()
+                        .AppendLine();
             }
 
             string shortOptPrefix = config.OptionConvention == OptionConvention.Windows ? "/" : "-";

--- a/getopt.net/Extensions.cs
+++ b/getopt.net/Extensions.cs
@@ -20,7 +20,7 @@ namespace getopt.net {
         public static Option? FindOptionOrDefault(this Option[] list, string optName) {
             if (string.IsNullOrEmpty(optName)) { throw new ArgumentNullException(nameof(optName), "optName must not be null!"); }
 
-            return list.FirstOrDefault(o => o.Name?.Equals(optName, StringComparison.InvariantCulture) == true);
+            return Array.Find(list, o => o.Name?.Equals(optName, StringComparison.InvariantCulture) == true);
         }
 
         /// <summary>
@@ -29,14 +29,14 @@ namespace getopt.net {
         /// <param name="list">The list of options to search.</param>
         /// <param name="optVal">The value to search for.</param>
         /// <returns>The <see cref="Option" /> with the <see cref="Option.Value" /> <paramref name="optVal" />, or <code >null</code> if no option was found matching the name.</returns>
-        public static Option? FindOptionOrDefault(this Option[] list, char optVal) => list.FirstOrDefault(o => o.Value == optVal);
+        public static Option? FindOptionOrDefault(this Option[]? list, char optVal) => list?.FirstOrDefault(o => o.Value == optVal);
 
         /// <summary>
         /// Creates a short opt string from an array of <see cref="Option"/> objects.
         /// </summary>
         /// <param name="list">The options to convert.</param>
         /// <returns><code>null</code> if the option list is empty or null. A string contain a shortopt-form string representing all the options from <paramref name="list"/>.</returns>
-        public static string? ToShortOptString(this Option[] list) {
+        public static string? ToShortOptString(this Option[]? list) {
             if (list is null || list.Length == 0) { return null; }
 
             var sBuilder = new StringBuilder();
@@ -55,6 +55,119 @@ namespace getopt.net {
             }
 
             return sBuilder.ToString();
+        }
+
+        /// <summary>
+        /// Generates a help text from the arguments contained in <paramref name="getopt" />. See <see cref="GetOpt.Options" /> for more information.
+        /// The method also takes a <see cref="HelpTextConfig" /> object to generate a help text. (<paramref name="generatorOptions" />)
+        /// If <paramref name="generatorOptions" /> is null, it will be assigned the value <see cref="HelpTextConfig.Default" />.
+        /// 
+        /// The help text is generated in the following format:
+        /// <code>
+        /// programName programVersion
+        /// 
+        /// Usage:
+        ///     programName [options]
+        /// 
+        /// Switches:
+        ///     ...
+        /// 
+        /// Options:
+        ///    ...
+        /// 
+        /// footerText
+        /// </code>
+        /// 
+        /// If <see cref="HelpTextConfig.ApplicationName"/> or <see cref="HelpTextConfig.ApplicationVersion" /> is null or empty, the first line will be omitted and the assembly name will be used in the usage.
+        /// If <see cref="HelpTextConfig.FooterText" /> is null or empty, the footer will be omitted.
+        /// 
+        /// The switches section will only contain options with the ArgumentType set to <see cref="ArgumentType.None" />.
+        /// The options section will only contain options with the ArgumentType set to <see cref="ArgumentType.Optional" /> or <see cref="ArgumentType.Required" />.
+        /// 
+        /// Each line containing the description of an option will be formatted as follows:
+        /// <code>
+        /// -s, --long-switch    Description of the switch
+        /// </code>
+        /// 
+        /// where the lines will be justified to the longest name.
+        /// </summary>
+        /// <param name="getopt">The instance of <see cref="GetOpt"/> to use.</param>
+        /// <param name="generatorOptions">(Optional) Customised generator configuration.</param>
+        /// <returns>A string value containing the help text.</returns>
+        public static string GenerateHelpText(this GetOpt getopt, HelpTextConfig? generatorOptions = null) {
+            if (getopt is null) { throw new ArgumentNullException(nameof(getopt), "getopt must not be null!"); }
+
+            var options = getopt.Options;
+            if (options is null || options.Length == 0) { return string.Empty; }
+
+            var config = generatorOptions ?? HelpTextConfig.Default;
+
+            var sBuilder = new StringBuilder();
+
+            if (!string.IsNullOrEmpty(config.ApplicationName) && !string.IsNullOrEmpty(config.ApplicationVersion)) {
+                sBuilder.AppendLine($"{config.ApplicationName} {config.ApplicationVersion}");
+                sBuilder.AppendLine();
+            }
+
+            string shortOptPrefix = config.OptionConvention == OptionConvention.Windows ? "/" : "-";
+            string longOptPrefix = config.OptionConvention == OptionConvention.Windows ? "/" : config.OptionConvention == OptionConvention.GnuPosix ? "--" : "-";
+
+            sBuilder.AppendLine("Usage:");
+            sBuilder.AppendLine($"\t{config.ApplicationName ?? GetApplicationName()} [options]");
+            if (config.ShowSupportedConventions) {
+                sBuilder.AppendLine(
+                    $"""
+
+                    Supported option conventions:
+                        Windows (/): {(getopt.AllowWindowsConventions ? "yes" : "no")}
+                        Powershell (-): {(getopt.AllowPowershellConventions ? "yes" : "no")}
+                        Gnu/Posix (-, --): yes
+                    """
+                );
+            }
+            sBuilder.AppendLine();
+
+            var longestName = options.Max(o => o.Name?.Length ?? 0);
+
+            sBuilder.AppendLine("Switches:");
+            foreach (var opt in options.Where(o => o.ArgumentType == ArgumentType.None)) {
+                sBuilder.AppendLine($"\t{shortOptPrefix}{(char)opt.Value}, {longOptPrefix:longestName}{opt.Name}\t{opt.Description}");
+            }
+            sBuilder.AppendLine();
+
+            sBuilder.AppendLine("Options:");
+            foreach (var opt in options.Where(o => o.ArgumentType == ArgumentType.Optional || o.ArgumentType == ArgumentType.Required)) {
+                var line = $"\t{shortOptPrefix}{(char)opt.Value}, {longOptPrefix:longestName}{opt.Name}\t{opt.Description ?? string.Empty}";
+                // If line is > config.MaxWidth, split it into multiple lines and align the description
+                if (line.Length > config.MaxWidth) {
+                    var desc = opt.Description ?? string.Empty;
+                    while (desc.Length > config.MaxWidth - longestName - 10) {
+                        var split = desc.Substring(0, config.MaxWidth - longestName - 10);
+                        var splitIndex = split.LastIndexOf(' ');
+                        sBuilder.AppendLine($"\t{new string(' ', longestName + 9)}{split.Substring(0, splitIndex)}");
+                        desc = desc.Substring(splitIndex + 1);
+                    }
+                    sBuilder.AppendLine($"\t{shortOptPrefix}{(char)opt.Value}, {longOptPrefix:longestName}{opt.Name}\t{desc}");
+                } else {
+                    sBuilder.AppendLine(line);
+                }
+
+                sBuilder.AppendLine();
+            }
+            sBuilder.AppendLine();
+
+            if (!string.IsNullOrEmpty(config.FooterText)) {
+                sBuilder.AppendLine(config.FooterText);
+            }
+
+            return sBuilder.ToString();
+        }
+
+        /// <summary>
+        /// Gets the name of the application.
+        /// </summary>
+        public static string GetApplicationName() {
+            return System.Reflection.Assembly.GetEntryAssembly()?.GetName().Name ?? "Unknown";
         }
 
     }

--- a/getopt.net/GetOpt.cs
+++ b/getopt.net/GetOpt.cs
@@ -177,7 +177,6 @@ namespace getopt.net {
         /// </remarks>
         public bool AllowParamFiles { get; set; } = false;
 
-
         /// <summary>
         /// Either enables or disabled exceptions entirely.
         /// For more specific control over exceptions, see the other options provided by GetOpt.

--- a/getopt.net/HelpTextConfig.cs
+++ b/getopt.net/HelpTextConfig.cs
@@ -15,7 +15,7 @@ namespace getopt.net {
         /// <summary>
         /// The maximum width of the help text.
         /// </summary>
-        public int MaxWidth { get; set; } = 160;
+        public int MaxWidth { get; set; } = 100;
 
         /// <summary>
         /// The option convention to use.

--- a/getopt.net/HelpTextConfig.cs
+++ b/getopt.net/HelpTextConfig.cs
@@ -1,0 +1,103 @@
+using System;
+
+namespace getopt.net {
+
+    /// <summary>
+    /// A class that contains configuration options for the help text generator.
+    /// </summary>
+    public sealed class HelpTextConfig {
+
+        /// <summary>
+        /// Whether to show the supported conventions in the help text.
+        /// </summary>
+        public bool ShowSupportedConventions { get; set; } = false;
+
+        /// <summary>
+        /// The maximum width of the help text.
+        /// </summary>
+        public int MaxWidth { get; set; } = 160;
+
+        /// <summary>
+        /// The option convention to use.
+        /// </summary>
+        public OptionConvention OptionConvention { get; set; } = OptionConvention.GnuPosix;
+
+        /// <summary>
+        /// The name of the application.
+        /// </summary>
+        public string? ApplicationName { get; set; }
+
+        /// <summary>
+        /// The version of the application.
+        /// </summary>
+        public string? ApplicationVersion { get; set; }
+
+        /// <summary>
+        /// A footer text to be displayed under the help text.
+        /// </summary>
+        public string? FooterText { get; set; }
+
+        /// <summary>
+        /// Gets a default configuration.
+        /// </summary>
+        public static HelpTextConfig Default => GnuConfig();
+
+        /// <summary>
+        /// Gets a configuration for the GNU/POSIX convention.
+        /// </summary>
+        public static HelpTextConfig GnuConfig() => new HelpTextConfig {
+            MaxWidth = 160,
+            OptionConvention = OptionConvention.GnuPosix,
+            ApplicationName = null,
+            ApplicationVersion = null,
+            FooterText = null
+        };
+
+        /// <summary>
+        /// Gets a configuration for the Windows convention.
+        /// </summary>
+        public static HelpTextConfig WindowsConfig() => new HelpTextConfig {
+            MaxWidth = 160,
+            OptionConvention = OptionConvention.Windows,
+            ApplicationName = null,
+            ApplicationVersion = null,
+            FooterText = null
+        };
+
+        /// <summary>
+        /// Gets a configuration for the Powershell convention.
+        /// </summary>
+        public static HelpTextConfig PowershellConfig() => new HelpTextConfig {
+            MaxWidth = 160,
+            OptionConvention = OptionConvention.Powershell,
+            ApplicationName = null,
+            ApplicationVersion = null,
+            FooterText = null
+        };
+
+    }
+
+    /// <summary>
+    /// An enumeration of option conventions.
+    /// </summary>
+    [Flags]
+    public enum OptionConvention {
+
+        /// <summary>
+        /// The GNU/POSIX convention.
+        /// </summary>
+        GnuPosix,
+
+        /// <summary>
+        /// The Windows convention.
+        /// </summary>
+        Windows,
+
+        /// <summary>
+        /// The Powershell convention.
+        /// </summary>
+        Powershell,
+
+    }
+
+}

--- a/getopt.net/HelpTextConfig.cs
+++ b/getopt.net/HelpTextConfig.cs
@@ -38,6 +38,16 @@ namespace getopt.net {
         public string? FooterText { get; set; }
 
         /// <summary>
+        /// The date of the copyright.
+        /// </summary>
+        public DateTime? CopyrightDate { get; set; }
+
+        /// <summary>
+        /// The holder of the copyright.
+        /// </summary>
+        public string? CopyrightHolder { get; set; }
+
+        /// <summary>
         /// Gets a default configuration.
         /// </summary>
         public static HelpTextConfig Default => GnuConfig();

--- a/getopt.net/Option.cs
+++ b/getopt.net/Option.cs
@@ -18,18 +18,21 @@ namespace getopt.net {
         /// <param name="name">The name of the argument.</param>
         /// <param name="argType">The argument type.</param>
         /// <param name="value">The value of the option.</param>
-        public Option(string name, ArgumentType argType, char value): this(name, argType, (int)value) { }
+        /// <param name="description">The description of the option.</param>
+        public Option(string name, ArgumentType argType, char value, string description = ""): this(name, argType, (int)value, description) {}
 
         /// <summary>
         /// Constructs a new instance of this struct with an <see cref="int"/> as the value type.
         /// </summary>
-        /// <param name="name"></param>
-        /// <param name="argType"></param>
-        /// <param name="value"></param>
-        public Option(string name, ArgumentType argType, int value) {
+        /// <param name="name">The name of the argument.</param>
+        /// <param name="argType">The argument type.</param>
+        /// <param name="value">The value of the option.</param>
+        /// <param name="description">The description of the option.</param>
+        public Option(string name, ArgumentType argType, int value, string description = "") {
             Name = name;
             ArgumentType = argType;
             Value = value;
+            Description = description;
         }
 
         /// <summary>
@@ -52,6 +55,11 @@ namespace getopt.net {
         /// The value (short opt) for the option.
         /// </summary>
         public int Value { get; set; }
+
+        /// <summary>
+        /// The description of the option.
+        /// </summary>
+        public string? Description { get; set; }
 
     }
 }

--- a/getopt.net/getopt.net.csproj
+++ b/getopt.net/getopt.net.csproj
@@ -22,15 +22,14 @@ GitHub: https://github.com/SimonCahill/getopt.net</Description>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
     <!--<ApplicationIcon >../img/getopt.net-icon.ico</ApplicationIcon>-->
-    <Version>0.9.1</Version>
+    <Version>1.0.0</Version>
     <PackageTags>getopt; getopt.net; argument-parsing; parser; arguments; options; getopt_long; options; command-line; cross-platform; linux; macos; windows</PackageTags>
-    <PackageReleaseNotes>
-# v0.9.1
-Version 0.9.1 introduces a non-breaking change which allows creating a shortopt string from an array of long options.
+    <PackageReleaseNotes># v1.0.0
+Version 1.0.0 introduces a non-breaking feature; the dynamic creation of help menus.
 
 ## Changes
- - Added extension method Option[].ToShortOptString()
- - Updated tests
+ - getopt.net now generates a dynamic help text.
+    - Added customisable extension method which can be used to dynamically generate help texts.
 
     </PackageReleaseNotes>
     <Title>getopt.net</Title>


### PR DESCRIPTION
This pull request adds a new, non-breaking feature: Help text generation.

With help text generation, getopt.net will generate a help text for your app with your inputs.

Usage:

```cs
getopt.CreateHelpText(new HelpTextConfig {
    // your settings here
});
```